### PR TITLE
Upgrade headplane

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -120,11 +120,11 @@
     "flake-compat_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1717312683,
-        "narHash": "sha256-FrlieJH50AuvagamEvWMIE6D2OAnERuDboFDYAED/dE=",
+        "lastModified": 1746162366,
+        "narHash": "sha256-5SSSZ/oQkwfcAz/o/6TlejlVGqeK08wyREBQ5qFFPhM=",
         "owner": "nix-community",
         "repo": "flake-compat",
-        "rev": "38fd3954cf65ce6faf3d0d45cd26059e059f07ea",
+        "rev": "0f158086a2ecdbb138cd0429410e44994f1b7e4b",
         "type": "github"
       },
       "original": {
@@ -159,11 +159,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741352980,
-        "narHash": "sha256-+u2UunDA4Cl5Fci3m7S643HzKmIDAe+fiXrLqYsR2fs=",
+        "lastModified": 1754487366,
+        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f4330d22f1c5d2ba72d3d22df5597d123fdb60a9",
+        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
         "type": "github"
       },
       "original": {
@@ -253,16 +253,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1751148639,
-        "narHash": "sha256-VbDtl4EEI8d0sWc5h7SArwey5Du+kdebqaUomSLZmPE=",
-        "owner": "igor-ramazanov",
+        "lastModified": 1755794245,
+        "narHash": "sha256-iQ/X8/82qkFhq/FVaNVDxOMKtklwZEtJQdCj/HghmqU=",
+        "owner": "tale",
         "repo": "headplane",
-        "rev": "6ccb0f3cea8af0eee38a3ef16cd2af6ad36d6e8f",
+        "rev": "d7b1e1998596cf8a270990b9f18c7ed90e559ee1",
         "type": "github"
       },
       "original": {
-        "owner": "igor-ramazanov",
-        "ref": "update-nix-changes-branch",
+        "owner": "tale",
+        "ref": "next",
         "repo": "headplane",
         "type": "github"
       }
@@ -347,29 +347,13 @@
         "type": "github"
       }
     },
-    "nixpkgs-overseerr": {
-      "locked": {
-        "lastModified": 1750707828,
-        "narHash": "sha256-mauT2LzsliBnZ68BekY1YiueSn24j/fJnzH7+3jEmVY=",
-        "owner": "jf-uu",
-        "repo": "nixpkgs",
-        "rev": "560eb7288d870d5616c87c55c6fea15ab61a348d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "jf-uu",
-        "ref": "overseerr",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1751984180,
-        "narHash": "sha256-LwWRsENAZJKUdD3SpLluwDmdXY9F45ZEgCb0X+xgOL0=",
+        "lastModified": 1755615617,
+        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9807714d6944a957c2e036f84b0ff8caf9930bc0",
+        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
         "type": "github"
       },
       "original": {
@@ -397,11 +381,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1751943650,
-        "narHash": "sha256-7orTnNqkGGru8Je6Un6mq1T8YVVU/O5kyW4+f9C1mZQ=",
+        "lastModified": 1755922037,
+        "narHash": "sha256-wY1+2JPH0ZZC4BQefoZw/k+3+DowFyfOxv17CN/idKs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "88983d4b665fb491861005137ce2b11a9f89f203",
+        "rev": "b1b3291469652d5a2edb0becc4ef0246fff97a7c",
         "type": "github"
       },
       "original": {
@@ -429,11 +413,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1751203939,
-        "narHash": "sha256-omYD+H5LlSihz2DRfv90I8Oeo7JNEwvcHPHX+6nMIM4=",
+        "lastModified": 1755716446,
+        "narHash": "sha256-AdVENrXoFws0sENT2Sz9SMavbqVJnATmCODuqJ7GcSs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "650e71cbf76de8dd16f5648a96981b726c4ef8fe",
+        "rev": "b0eccfbc0168243438e8a6747fcdfb1bb796a3f7",
         "type": "github"
       },
       "original": {
@@ -501,7 +485,6 @@
         "headplane": "headplane",
         "nixarr": "nixarr",
         "nixpkgs": "nixpkgs_3",
-        "nixpkgs-overseerr": "nixpkgs-overseerr",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "sops-nix": "sops-nix",
         "srvos": "srvos",
@@ -514,11 +497,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1751606940,
-        "narHash": "sha256-KrDPXobG7DFKTOteqdSVeL1bMVitDcy7otpVZWDE6MA=",
+        "lastModified": 1754988908,
+        "narHash": "sha256-t+voe2961vCgrzPFtZxha0/kmFSHFobzF00sT8p9h0U=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "3633fc4acf03f43b260244d94c71e9e14a2f6e0d",
+        "rev": "3223c7a92724b5d804e9988c6b447a0d09017d48",
         "type": "github"
       },
       "original": {
@@ -532,11 +515,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1751564530,
-        "narHash": "sha256-DybnqQMmkMEbNQhrbMGFijZCa9g5mtYIMPACVNMJ5u8=",
+        "lastModified": 1755770475,
+        "narHash": "sha256-piB4s87GvBJkzWLbzOMyX4adjMBmTMxzMu0SNT/b8hU=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "6bb452f0b31058ffe64241bcf092ebf1c7758be1",
+        "rev": "bebcf12b45df0b7d6f422ebd5da06f92b52169a8",
         "type": "github"
       },
       "original": {
@@ -613,11 +596,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742370146,
-        "narHash": "sha256-XRE8hL4vKIQyVMDXykFh4ceo3KSpuJF3ts8GKwh5bIU=",
+        "lastModified": 1754847726,
+        "narHash": "sha256-2vX8QjO5lRsDbNYvN9hVHXLU6oMl+V/PsmIiJREG4rE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "adc195eef5da3606891cedf80c0d9ce2d3190808",
+        "rev": "7d81f6fb2e19bf84f1c65135d1060d829fae2408",
         "type": "github"
       },
       "original": {
@@ -695,11 +678,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1750793560,
-        "narHash": "sha256-0stdTfzb9lueotisMqpjv8FVYJouTaxSeMj2C8frfeA=",
+        "lastModified": 1755850839,
+        "narHash": "sha256-0aAhp7XMubgV3fDwkwWRramSFo8UNgsDF2RIrcOLsXc=",
         "owner": "flyingcircusio",
         "repo": "vulnix",
-        "rev": "f7d81fd143855c9302dab4736f3de2ce3375ff62",
+        "rev": "6f35dda4ae5039f87ee09948ca6a01df5e91dd25",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -365,11 +365,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1750776420,
-        "narHash": "sha256-/CG+w0o0oJ5itVklOoLbdn2dGB0wbZVOoDm4np6w09A=",
+        "lastModified": 1751984180,
+        "narHash": "sha256-LwWRsENAZJKUdD3SpLluwDmdXY9F45ZEgCb0X+xgOL0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "30a61f056ac492e3b7cdcb69c1e6abdcf00e39cf",
+        "rev": "9807714d6944a957c2e036f84b0ff8caf9930bc0",
         "type": "github"
       },
       "original": {
@@ -397,11 +397,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1750838302,
-        "narHash": "sha256-aVkL3/yu50oQzi2YuKo0ceiCypVZpZXYd2P2p1FMJM4=",
+        "lastModified": 1751943650,
+        "narHash": "sha256-7orTnNqkGGru8Je6Un6mq1T8YVVU/O5kyW4+f9C1mZQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7284e2decc982b81a296ab35aa46e804baaa1cfe",
+        "rev": "88983d4b665fb491861005137ce2b11a9f89f203",
         "type": "github"
       },
       "original": {
@@ -429,11 +429,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1750878217,
-        "narHash": "sha256-iZZ2tr22ObTPmwpIsHxPpNV9JmUjoOzDXq07uK9GS30=",
+        "lastModified": 1751203939,
+        "narHash": "sha256-omYD+H5LlSihz2DRfv90I8Oeo7JNEwvcHPHX+6nMIM4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6c075ca0b235e58e18bc167560bb6bbfe5c18e1b",
+        "rev": "650e71cbf76de8dd16f5648a96981b726c4ef8fe",
         "type": "github"
       },
       "original": {
@@ -514,11 +514,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1750119275,
-        "narHash": "sha256-Rr7Pooz9zQbhdVxux16h7URa6mA80Pb/G07T4lHvh0M=",
+        "lastModified": 1751606940,
+        "narHash": "sha256-KrDPXobG7DFKTOteqdSVeL1bMVitDcy7otpVZWDE6MA=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "77c423a03b9b2b79709ea2cb63336312e78b72e2",
+        "rev": "3633fc4acf03f43b260244d94c71e9e14a2f6e0d",
         "type": "github"
       },
       "original": {
@@ -532,11 +532,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1750907330,
-        "narHash": "sha256-rXA4RdUfZxBmy3RZ8TiP9ITuGwLGBWlyP16dN6ILS6M=",
+        "lastModified": 1751564530,
+        "narHash": "sha256-DybnqQMmkMEbNQhrbMGFijZCa9g5mtYIMPACVNMJ5u8=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "3af451e7eb42df68fc06b689da4f4ca7198eed5e",
+        "rev": "6bb452f0b31058ffe64241bcf092ebf1c7758be1",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -253,16 +253,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1747685575,
-        "narHash": "sha256-+OzE8WBGCVbzRI1+lLoElpZvGobJeCz0bGNUTSFFlbE=",
-        "owner": "StealthBadger747",
+        "lastModified": 1751148639,
+        "narHash": "sha256-VbDtl4EEI8d0sWc5h7SArwey5Du+kdebqaUomSLZmPE=",
+        "owner": "igor-ramazanov",
         "repo": "headplane",
-        "rev": "82810b769520802202600a9a4a4d53f1e639d837",
+        "rev": "6ccb0f3cea8af0eee38a3ef16cd2af6ad36d6e8f",
         "type": "github"
       },
       "original": {
-        "owner": "StealthBadger747",
-        "ref": "erikp/implement-path-loader",
+        "owner": "igor-ramazanov",
+        "ref": "update-nix-changes-branch",
         "repo": "headplane",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,8 @@
     };
     flake-utils.url = "github:numtide/flake-utils";
     headplane = {
-      url = "github:StealthBadger747/headplane/erikp/implement-path-loader";
+      # url = "github:StealthBadger747/headplane/erikp/implement-path-loader";
+      url = "github:igor-ramazanov/headplane/update-nix-changes-branch";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     ycotd-python-queue = {
@@ -224,10 +225,10 @@
           nano
           nh
         ]) ++ ( with pkgs-unstable; [
-          oci-cli
-          opentofu
+          # oci-cli
+          # opentofu
           deploy-rs.packages.${system}.default
-          vulnix.packages.${system}.default
+          # vulnix.packages.${system}.default
         ]);
 
         shellHook = ''

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,6 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
-    nixpkgs-overseerr.url = "github:jf-uu/nixpkgs/overseerr";
     sops-nix.url = "github:Mic92/sops-nix";
     authentik-nix.url = "github:marcelcoding/authentik-nix";
     # authentik-nix.url = "github:nix-community/authentik-nix";
@@ -36,8 +35,7 @@
     };
     flake-utils.url = "github:numtide/flake-utils";
     headplane = {
-      # url = "github:StealthBadger747/headplane/erikp/implement-path-loader";
-      url = "github:igor-ramazanov/headplane/update-nix-changes-branch";
+      url = "github:tale/headplane/next";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     ycotd-python-queue = {
@@ -50,7 +48,7 @@
     };
   };
 
-  outputs = { self, nixpkgs, nixpkgs-unstable, nixpkgs-overseerr, sops-nix, authentik-nix
+  outputs = { self, nixpkgs, nixpkgs-unstable, sops-nix, authentik-nix
     , srvos, deploy-rs, vulnix, flake-utils, headplane, ycotd-python-queue, nixarr }:
     let
       # Systems we want to support
@@ -70,16 +68,6 @@
       # Helper function to initialize pkgs-unstable
       mkPkgsUnstable = system:
         import nixpkgs-unstable {
-          inherit system;
-          config.allowUnfree = true;
-          crossSystem = if system == "aarch64-linux" then {
-            config = "aarch64-unknown-linux-gnu";
-            system = "aarch64-linux";
-          } else null;
-        };
-
-      mkCustomExtraPackages = system:
-        import nixpkgs-overseerr {
           inherit system;
           config.allowUnfree = true;
           crossSystem = if system == "aarch64-linux" then {
@@ -282,7 +270,6 @@
           ];
           specialArgs = {
             pkgs-unstable = mkPkgsUnstable "x86_64-linux";
-            pkgs-overseerr = mkCustomExtraPackages "x86_64-linux";
             inherit nixarr;
           };
         };

--- a/modules/hosts/oracle-cloud/free-x86.nix
+++ b/modules/hosts/oracle-cloud/free-x86.nix
@@ -96,7 +96,7 @@ in {
       enable = true;
       address = "127.0.0.1";
       port = 8080;
-      package = pkgs-unstable.headscale;
+      # package = pkgs-unstable.headscale;
       settings = {
         server_url = "https://${headscale_fqdn}";
         dns.base_domain = "internal-${headscale_fqdn}";
@@ -164,20 +164,22 @@ in {
         };
         headscale = {
           url = "https://${headscale_fqdn}";
+          config_path = "${headscaleConfig}";
+          config_strict = true;
           # config_path = "${headscaleConfig}";
           # config_strict = false;
-          config_path = "${(pkgs.formats.yaml {}).generate "headscale.yml" (
-            lib.recursiveUpdate
-            config.services.headscale.settings
-            {
-              acme_email = "/dev/null";
-              tls_cert_path = "/dev/null";
-              tls_key_path = "/dev/null";
-              policy.path = "/dev/null";
-              oidc.client_secret_path = "/dev/null";
-            }
-          )}";
-          config_strict = true;
+          # config_path = "${(pkgs.formats.yaml {}).generate "headscale.yml" (
+          #   lib.recursiveUpdate
+          #   config.services.headscale.settings
+          #   {
+          #     acme_email = "/dev/null";
+          #     tls_cert_path = "/dev/null";
+          #     tls_key_path = "/dev/null";
+          #     policy.path = "/dev/null";
+          #     oidc.client_secret_path = "/dev/null";
+          #   }
+          # )}";
+          # config_strict = true;
         };
         integration.proc.enabled = true;
         oidc = {

--- a/modules/hosts/oracle-cloud/free-x86.nix
+++ b/modules/hosts/oracle-cloud/free-x86.nix
@@ -164,8 +164,20 @@ in {
         };
         headscale = {
           url = "https://${headscale_fqdn}";
-          config_path = "${headscaleConfig}";
-          config_strict = false;
+          # config_path = "${headscaleConfig}";
+          # config_strict = false;
+          config_path = "${(pkgs.formats.yaml {}).generate "headscale.yml" (
+            lib.recursiveUpdate
+            config.services.headscale.settings
+            {
+              acme_email = "/dev/null";
+              tls_cert_path = "/dev/null";
+              tls_key_path = "/dev/null";
+              policy.path = "/dev/null";
+              oidc.client_secret_path = "/dev/null";
+            }
+          )}";
+          config_strict = true;
         };
         integration.proc.enabled = true;
         oidc = {
@@ -176,6 +188,7 @@ in {
           token_endpoint_auth_method = "client_secret_basic";
           headscale_api_key_path = config.sops.secrets.headplane_headscale_api_key.path;
           redirect_uri = "https://${headscale_fqdn}/admin/oidc/callback";
+          user_storage_file = "/var/lib/headplane/users.json";
         };
       };
     };

--- a/modules/hosts/oracle-cloud/free-x86.nix
+++ b/modules/hosts/oracle-cloud/free-x86.nix
@@ -7,14 +7,9 @@ let
 
   headplane_port = "3000";
   headplane_host = "127.0.0.1";
-
-  settingsFormat = pkgs.formats.yaml { };
-  headscaleConfig = settingsFormat.generate "headscale-settings.yaml"
-    config.services.headscale.settings;
 in {
-  environment.etc."headscale/config.yaml".source = lib.mkForce
-    (settingsFormat.generate "headscale-config.yaml"
-      config.services.headscale.settings);
+  disabledModules = [ "services/networking/headscale.nix" ];
+  imports = [ "${pkgs-unstable.path}/nixos/modules/services/networking/headscale.nix" ];
 
   sops = {
     defaultSopsFile = ../../../secrets/secrets.yaml;
@@ -52,6 +47,12 @@ in {
         mode = "0400";
       };
       headplane_headscale_api_key = {
+        sopsFile = ../../../secrets/hosts/oracle-cloud/free-x86.yaml;
+        owner = "headscale";
+        group = "headscale";
+        mode = "0400";
+      };
+      headplane_pre_authkey = {
         sopsFile = ../../../secrets/hosts/oracle-cloud/free-x86.yaml;
         owner = "headscale";
         group = "headscale";
@@ -96,28 +97,30 @@ in {
       enable = true;
       address = "127.0.0.1";
       port = 8080;
-      # package = pkgs-unstable.headscale;
+      package = pkgs-unstable.headscale;
       settings = {
         server_url = "https://${headscale_fqdn}";
-        dns.base_domain = "internal-${headscale_fqdn}";
-        oidc = {
+        dns = {
+          magic_dns = true;
+          base_domain = "internal-${headscale_fqdn}";
+          override_local_dns = false;
+          nameservers.global = [ "1.1.1.1" "1.0.0.1" "2606:4700:4700::1111" "2606:4700:4700::1001" ];
+        };
+        policy.mode = "database";
+        oidc = lib.mkForce { # lib.mkForce was a hack to deal with the options for headscale being defined by 25.1 nixos stable, but 
+                             # I wanted to use 26.1 on the nixos unstable branch. However the options conflicted.
           issuer =
             "https://authentik.parawell.cloud/application/o/test-headscale/";
           client_id = "FylC3SexPmVQagmIx7mT1FrmXpzpjHdQzykXRfMK";
           client_secret_path =
             config.sops.secrets.headscale_oidc_client_secret.path;
           scope = [ "openid" "profile" "email" ];
-          # extra_params = {
-          #   domain_hint = "parawell.cloud";
-          # };
           allowed_users = [
             "parawell.erik@gmail.com"
             "ac130kire@gmail.com"
             "connor@connorgolden.me"
             "nedimazar@gmail.com"
           ];
-          # allowed_domains = [ "parawell.cloud" ];
-          strip_email_domain = true;
         };
       };
     };
@@ -137,7 +140,7 @@ in {
             "http://127.0.0.1:${toString config.services.headscale.port}";
           proxyWebsockets = true;
         };
-        locations."/admin" = {
+        locations."/admin/" = {
           proxyPass = "http://127.0.0.1:${toString config.services.headplane.settings.server.port}";
           proxyWebsockets = true;
         };
@@ -149,9 +152,6 @@ in {
 
     headplane = {
       enable = true;
-      agent = {
-        enable = false;
-      };
       settings = {
         server = {
           host = headplane_host;
@@ -159,27 +159,24 @@ in {
           cookie_secret_path = config.sops.secrets.headplane_cookie_secret.path;
           cookie_secure = true;
         };
-        agent = {
-          enabled = false;
+        integration = {
+          agent = {
+            enabled = true;
+            pre_authkey_path = config.sops.secrets.headplane_pre_authkey.path;
+          };
         };
         headscale = {
           url = "https://${headscale_fqdn}";
-          config_path = "${headscaleConfig}";
+          config_path = "${(pkgs.formats.yaml {}).generate "headscale.yml" (
+            lib.recursiveUpdate
+            config.services.headscale.settings
+            {
+              tls_cert_path = "/dev/null";
+              tls_key_path = "/dev/null";
+              policy.path = "/dev/null";
+            }
+          )}";
           config_strict = true;
-          # config_path = "${headscaleConfig}";
-          # config_strict = false;
-          # config_path = "${(pkgs.formats.yaml {}).generate "headscale.yml" (
-          #   lib.recursiveUpdate
-          #   config.services.headscale.settings
-          #   {
-          #     acme_email = "/dev/null";
-          #     tls_cert_path = "/dev/null";
-          #     tls_key_path = "/dev/null";
-          #     policy.path = "/dev/null";
-          #     oidc.client_secret_path = "/dev/null";
-          #   }
-          # )}";
-          # config_strict = true;
         };
         integration.proc.enabled = true;
         oidc = {

--- a/modules/hosts/pilatus/pc24.nix
+++ b/modules/hosts/pilatus/pc24.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, pkgs-unstable, pkgs-overseerr, lib, nixarr, ... }:
+{ config, pkgs, pkgs-unstable, lib, nixarr, ... }:
 let
   host = "pilatus";
   tld = "parawell.cloud";
@@ -169,7 +169,6 @@ in {
     
     overseerr = {
       enable = true;
-      package = pkgs-overseerr.overseerr;
       stateDir = "/APPS/arr-apps/overseerr";
       openFirewall = true;
     };

--- a/modules/overlays/nixarr/overseerr.nix
+++ b/modules/overlays/nixarr/overseerr.nix
@@ -3,13 +3,13 @@
   config,
   lib,
   pkgs,
-  pkgs-overseerr ? null,
+  pkgs-unstable,
   ...
 }:
 with lib; let
   cfg = config.nixarr.overseerr;
   nixarr = config.nixarr;
-  pkg = if pkgs-overseerr != null then pkgs-overseerr.overseerr else pkgs.overseerr;
+  pkg = pkgs-unstable.overseerr;
 in {
   options.nixarr.overseerr = {
     enable = mkOption {

--- a/secrets/hosts/oracle-cloud/free-x86.yaml
+++ b/secrets/hosts/oracle-cloud/free-x86.yaml
@@ -1,6 +1,7 @@
 headplane_cookie_secret: ENC[AES256_GCM,data:f7pw9HHZzkIhgK937cke+LXD9bo+V6PunTAInMuDaDE=,iv:JaZ91JFLgqsM0iKInVWdzQpSXPVeGrQ0+35L/x7DE/E=,tag:jWiDqlVWbZ7Mbflsehequw==,type:str]
 headplane_oidc_client_secret: ENC[AES256_GCM,data:37pBOylATZDz3LP2Lg64hQLFiE9VzB1MD75NAxBla/jz0DqLtYJNcA==,iv:Rl8lIrQTKfKCCGwpxawi+tBwCKlKxKOX4M3shy+nXKg=,tag:wKVY5JMqns5JAyMxhIWB5g==,type:str]
-headplane_headscale_api_key: ENC[AES256_GCM,data:S0sEuSgGcWVoa3O18Qk7keG/bDwuSt3dxlnz6ogXIJHKjnXxJ7wzEg==,iv:7nmzYdg07kRtAreoY4uhXYgWAdm0WlLmi/gsADEOhKg=,tag:BWGQbG2CxUDTCFbagPJarA==,type:str]
+headplane_headscale_api_key: ENC[AES256_GCM,data:hHNMDNtuRsryFjHLRagZZuJk+WeVEoHdTTX66bd1+kEg48aJWJQdAA==,iv:wd9WaOz69NSZYcUiWT3ct08MLWZuLuYbtiIEt/UPOPA=,tag:gWDoUle9Crcmugqe0SlxMw==,type:str]
+headplane_pre_authkey: ENC[AES256_GCM,data:1g8I+Xielmg6qMb+prSLaaay6/6gDfGuQ2nVF5syKcHYyI7QdcjznVnrprU07sp3,iv:ABdG2qVuxoYCnGI8JtK7ejRBmFteZQE4gnvFYNKmrOw=,tag:T26Kz7L+jp+YVMJymt4jQw==,type:str]
 sops:
     age:
         - recipient: age1qwuz9ud98q82xpresskwkgd20r35u0valpddq973h2a9dad6cyjqxqmzt2
@@ -39,7 +40,7 @@ sops:
             cFBxQ2pkTnkrbm5LNmtmNmdYTWp4czQKJzkNB9PNuCagZMd7mJ+7F7bYegvcqeMK
             pcULb043R2tQDVKOXZytP3Q0TTP3tE58wVO5eMrXxHL5GwC96UQo+A==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-05-11T08:12:38Z"
-    mac: ENC[AES256_GCM,data:uF8hOf1Bvnc7hDRihu6jDZyu9CriXc7O4q8LYK51tiRFTpXcc1u88CrIEH1y8gmJQfNPg8+Xv+51DpVDXyJlM5iZD5P7voyFa63Sgn21LDuUfqWOkja0F1e/1+03NixE4Gnqe8BUuCTAjp6gb1oNDlI/9rjJ2Y+qIjomuwQnGeI=,iv:p1n5gnPFVDoZJYcjC9jmMdndMzlcny82sschQLY4thY=,tag:Xj9rubSEbEvYCT7osPOAEQ==,type:str]
+    lastmodified: "2025-08-26T21:20:33Z"
+    mac: ENC[AES256_GCM,data:/UxCGJ2Dto86KGMLSOAaTR1MNO1Vmdr2AEO+mkHjqAsjOEo4uuQGaz9SrkcEjDDiHny6hjlqVYw2joshYb85uCBoi4tODMUewp7FBxFInIJNdPE4mfdV7NpCWwPp7U5ONslq1W9f8454SmcCoAZXGR058K2lphd9nenlLJqrr6U=,iv:V2A7L4oFnpNB8jx82qSv+1r8c6D5GgMz18bse7f5OHI=,tag:1ocRUa4OmhU946glm43RHg==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.9.4
+    version: 3.10.2


### PR DESCRIPTION
 - Upgrade headscale from 25.1 to 26.1
 - Upgrade headplane to the current (next) branch
 - Remove the overseer nixpkgs flake input because it has been merged.