### PR TITLE
K3S upgrades

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -5,7 +5,7 @@ keys:
   - &pc_24 age1y2g734aqge4lsvmf8dw6s5rc8rkd0scmfwvxm3nlat6tu7y60a2s94yn0l
   - &erik_mbp age17fq29yexw9rf30je5xp86hdda6tgug52sax7vy0af2sngempqv0qwhe4vr
   - &gha_ci age1tpupgevxd2d50zv95c098c3xkfqed4zk46h8fag9stadj75dvu0q3wx0mk
-  - &zagato_master_1 age1xeltrwejcsrx8l8usdwhw460gl9wc83etwsk0peszhyngv9gns8qcg55rq
+  - &zagato_master_1 age1w8kqhxusrglw4697ku3r0v6r0x42am4d6l8k6en96uvf7dxyrqeqwf3nsy
   - &zagato_master_2 age1lm2j0n3e52ve6pdeqjxkuuxs4wgtm0tv2t92x8c5ayjwm0lwxv6qsruxdq
   - &zagato_master_3 age1nkz255qkgpwy4myetz9dyl5hdh2cpenv52fgpya5gwdc5e9prqhq7ns4lq
   - &erikp_home_desktop age1wj8d6dpv8xt5m2kpusxzfkfuedp5j4qjszrtg0tnzevgkd3sla8q0wms67

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -4,10 +4,13 @@ keys:
   - &oci_authentik age1hj5dyl0wzlq92ms2hrut6he05dqv0pknlv7wpyv2jywhz2hqwe9qgpt5dl
   - &pc_24 age1y2g734aqge4lsvmf8dw6s5rc8rkd0scmfwvxm3nlat6tu7y60a2s94yn0l
   - &erik_mbp age17fq29yexw9rf30je5xp86hdda6tgug52sax7vy0af2sngempqv0qwhe4vr
-  - &gha_ci age1tpupgevxd2d50zv95c098c3xkfqed4zk46h8fag9stadj75dvu0q3wx0mk
+  - &gha_ci age1wcuzeqxgdmv6ev0ufawnu699pyxrqq565tae79sa2jfgnffvlvmq5xd03h
   - &zagato_master_1 age1w8kqhxusrglw4697ku3r0v6r0x42am4d6l8k6en96uvf7dxyrqeqwf3nsy
   - &zagato_master_2 age1lm2j0n3e52ve6pdeqjxkuuxs4wgtm0tv2t92x8c5ayjwm0lwxv6qsruxdq
   - &zagato_master_3 age1nkz255qkgpwy4myetz9dyl5hdh2cpenv52fgpya5gwdc5e9prqhq7ns4lq
+  - &zagato_worker_1 age1htmygjfah9sxpnkky6nrcn3p5wj2d3ml5d06nux6djefcd2p854qtt8ta3
+  - &zagato_worker_2 age1s6af7sfp4elds8507wjtluuavju82kreqsjx9k8z6e84nwngtglqfracwg
+  - &zagato_shared_cloudinit age1jha9zrxs682wl53767u5gzm26terltfs2lcmd4djyj8t69t4se9qqrq83s
   - &erikp_home_desktop age1wj8d6dpv8xt5m2kpusxzfkfuedp5j4qjszrtg0tnzevgkd3sla8q0wms67
 creation_rules:
   - path_regex: secrets/secrets.yaml$
@@ -56,6 +59,9 @@ creation_rules:
       - *zagato_master_1
       - *zagato_master_2
       - *zagato_master_3
+      - *zagato_worker_1
+      - *zagato_worker_2
+      - *zagato_shared_cloudinit
       - *erik_mbp
       - *gha_ci
       - *erikp_home_desktop

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -6,8 +6,8 @@ keys:
   - &erik_mbp age17fq29yexw9rf30je5xp86hdda6tgug52sax7vy0af2sngempqv0qwhe4vr
   - &gha_ci age1wcuzeqxgdmv6ev0ufawnu699pyxrqq565tae79sa2jfgnffvlvmq5xd03h
   - &zagato_master_1 age1w8kqhxusrglw4697ku3r0v6r0x42am4d6l8k6en96uvf7dxyrqeqwf3nsy
-  - &zagato_master_2 age1lm2j0n3e52ve6pdeqjxkuuxs4wgtm0tv2t92x8c5ayjwm0lwxv6qsruxdq
-  - &zagato_master_3 age1nkz255qkgpwy4myetz9dyl5hdh2cpenv52fgpya5gwdc5e9prqhq7ns4lq
+  - &zagato_master_2 age1uev6mgsfdkakk2kps2f6d05t9wckh5ex0dfxfwnfgyt20kyaxp6q0xzkd8
+  - &zagato_master_3 age1ddlymgwgj5p7438pltp6rfdpdwul54gsp0ue8az4jg22x82m7v9qgfev9n
   - &zagato_worker_1 age1htmygjfah9sxpnkky6nrcn3p5wj2d3ml5d06nux6djefcd2p854qtt8ta3
   - &zagato_worker_2 age1s6af7sfp4elds8507wjtluuavju82kreqsjx9k8z6e84nwngtglqfracwg
   - &zagato_shared_cloudinit age1jha9zrxs682wl53767u5gzm26terltfs2lcmd4djyj8t69t4se9qqrq83s

--- a/flake.lock
+++ b/flake.lock
@@ -14,11 +14,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1757062396,
-        "narHash": "sha256-403iuoMVVjk64sF1GgZfrRwOnVU1H14sflE+LNp927c=",
+        "lastModified": 1759322529,
+        "narHash": "sha256-yiv/g/tiJI3PI95F7vhTnaf1TDsIkFLrmmFTjWfb6pQ=",
         "owner": "nix-community",
         "repo": "authentik-nix",
-        "rev": "22827e9a0cc002a076ee8bd14c3433ebc6c87f95",
+        "rev": "69fac057b2e553ee17c9a09b822d735823d65a6c",
         "type": "github"
       },
       "original": {
@@ -30,16 +30,16 @@
     "authentik-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1755873658,
-        "narHash": "sha256-5l1g55b0xozGg0NaZFimiO5JbHGcudaNSEn1/XsweaU=",
+        "lastModified": 1759190535,
+        "narHash": "sha256-pIzDaoDWc58cY/XhsyweCwc4dfRvkaT/zqsV1gDSnCI=",
         "owner": "goauthentik",
         "repo": "authentik",
-        "rev": "dd7c6b29d950664deadbcf5390272619a8bf9a5e",
+        "rev": "8d3a289d12c7de2f244c76493af7880f70d08af2",
         "type": "github"
       },
       "original": {
         "owner": "goauthentik",
-        "ref": "version/2025.8.1",
+        "ref": "version/2025.8.4",
         "repo": "authentik",
         "type": "github"
       }
@@ -138,11 +138,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1754487366,
-        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
+        "lastModified": 1756770412,
+        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
+        "rev": "4524271976b625a4a605beefd893f270620fd751",
         "type": "github"
       },
       "original": {
@@ -253,11 +253,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756436126,
-        "narHash": "sha256-HcSMULXzZ/k4rVZ4Ns6E3i90i0m88BJWskMeO6n8k9s=",
+        "lastModified": 1760034875,
+        "narHash": "sha256-MT1zATnTsePDK9taLO2lVtVdG91ACeaGsV99GNq9Pzg=",
         "owner": "tale",
         "repo": "headplane",
-        "rev": "eb4669498a26f198b5a2b5343114ad685cc5b143",
+        "rev": "43cbc177d62186a0ff16e162526e23536ec09398",
         "type": "github"
       },
       "original": {
@@ -318,11 +318,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1756386758,
-        "narHash": "sha256-1wxxznpW2CKvI9VdniaUnTT2Os6rdRJcRUf65ZK9OtE=",
+        "lastModified": 1757745802,
+        "narHash": "sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dfb2f12e899db4876308eba6d93455ab7da304cd",
+        "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
         "type": "github"
       },
       "original": {
@@ -334,11 +334,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1753579242,
-        "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
+        "lastModified": 1754788789,
+        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "0f36c44e01a6129be94e3ade315a5883f0228a6e",
+        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
         "type": "github"
       },
       "original": {
@@ -349,11 +349,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1757487488,
-        "narHash": "sha256-zwE/e7CuPJUWKdvvTCB7iunV4E/+G0lKfv4kk/5Izdg=",
+        "lastModified": 1759831965,
+        "narHash": "sha256-vgPm2xjOmKdZ0xKA6yLXPJpjOtQPHfaZDRtH+47XEBo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ab0f3607a6c7486ea22229b92ed2d355f1482ee0",
+        "rev": "c9b6fb798541223bbb396d287d16f43520250518",
         "type": "github"
       },
       "original": {
@@ -381,11 +381,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1757545623,
-        "narHash": "sha256-mCxPABZ6jRjUQx3bPP4vjA68ETbPLNz9V2pk9tO7pRQ=",
+        "lastModified": 1759735786,
+        "narHash": "sha256-a0+h02lyP2KwSNrZz4wLJTu9ikujNsTWIC874Bv7IJ0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8cd5ce828d5d1d16feff37340171a98fc3bf6526",
+        "rev": "20c4598c84a671783f741e02bf05cbfaf4907cff",
         "type": "github"
       },
       "original": {
@@ -397,11 +397,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1757034884,
-        "narHash": "sha256-PgLSZDBEWUHpfTRfFyklmiiLBE1i1aGCtz4eRA3POao=",
+        "lastModified": 1759570798,
+        "narHash": "sha256-kbkzsUKYzKhuvMOuxt/aTwWU2mnrwoY964yN3Y4dE98=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ca77296380960cd497a765102eeb1356eb80fed0",
+        "rev": "0d4f673a88f8405ae14484e6a1ea870e0ba4ca26",
         "type": "github"
       },
       "original": {
@@ -413,11 +413,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1757493204,
-        "narHash": "sha256-bwg0O7Xo/T7aTWp0zicklTonSULI33Y1LMsqFBmTIf8=",
+        "lastModified": 1759336499,
+        "narHash": "sha256-qIdMRH5NE0tRshQJLPiuVi8lcTwxseSNPVeCWyyExwY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f9e9d45a64c8ff4e9906260804a1679a28819b4e",
+        "rev": "7c6a695ef58d1fc935b9b2cb728c654e78c20db5",
         "type": "github"
       },
       "original": {
@@ -443,11 +443,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756087852,
-        "narHash": "sha256-4jc3JDQt75fYXFrglgqyzF6C6zLU0QGLymzian4aP+U=",
+        "lastModified": 1757296493,
+        "narHash": "sha256-6nzSZl28IwH2Vx8YSmd3t6TREHpDbKlDPK+dq1LKIZQ=",
         "owner": "pyproject-nix",
         "repo": "build-system-pkgs",
-        "rev": "6edb3ae27395cd88be3d64b732d1539957dad59c",
+        "rev": "5b8e37fe0077db5c1df3a5ee90a651345f085d38",
         "type": "github"
       },
       "original": {
@@ -464,11 +464,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756395552,
-        "narHash": "sha256-5aJM14MpoLk2cdZAetu60OkLQrtFLWTICAyn1EP7ZpM=",
+        "lastModified": 1757246327,
+        "narHash": "sha256-6pNlGhwOIMfhe/RLjHdpXveKS4FyLHvlGe+KtjDild4=",
         "owner": "pyproject-nix",
         "repo": "pyproject.nix",
-        "rev": "030dffc235dcf240d918c651c78dc5f158067b51",
+        "rev": "8d77f342d66ad1601cdb9d97e9388b69f64d4c8e",
         "type": "github"
       },
       "original": {
@@ -497,11 +497,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1757503115,
-        "narHash": "sha256-S9F6bHUBh+CFEUalv/qxNImRapCxvSnOzWBUZgK1zDU=",
+        "lastModified": 1759635238,
+        "narHash": "sha256-UvzKi02LMFP74csFfwLPAZ0mrE7k6EiYaKecplyX9Qk=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "0bf793823386187dff101ee2a9d4ed26de8bbf8c",
+        "rev": "6e5a38e08a2c31ae687504196a230ae00ea95133",
         "type": "github"
       },
       "original": {
@@ -515,11 +515,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1757552363,
-        "narHash": "sha256-4dtGagSfwMabRi59g7E8T6FcdghNizLbR4PwU1g8lDI=",
+        "lastModified": 1759366584,
+        "narHash": "sha256-GoeShBq/+xv9g9POP69vbOrObpLtS/mDfF1/pfPIQrU=",
         "owner": "nix-community",
         "repo": "srvos",
-        "rev": "ec58f16bdb57cf3a17bba79f687945dca1703c64",
+        "rev": "1dbb22b9b15f449a7c8c92a94aec9fe5aea8ef7c",
         "type": "github"
       },
       "original": {
@@ -639,11 +639,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756466761,
-        "narHash": "sha256-ALXRHIMXQ4qVNfCbcWykC23MjMwUoHn9BreoBfqmq0Y=",
+        "lastModified": 1757925761,
+        "narHash": "sha256-7Hwz0vfHuFqCo5v7Q07GQgLBWuPvZCuf/5/pk4NoADg=",
         "owner": "pyproject-nix",
         "repo": "uv2nix",
-        "rev": "0529e6d8227517205afcd1b37eee3088db745730",
+        "rev": "780494c40895bb7419a73d942bee326291e80b3b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -261,6 +261,7 @@
           sops
           nano
           nh
+          bashInteractive
         ]) ++ ( with pkgs-unstable; [
           # oci-cli
           # opentofu

--- a/flake.nix
+++ b/flake.nix
@@ -198,6 +198,28 @@
             echo "This package can only be built on x86_64-linux systems"
             exit 1
           '';
+
+        k3s-worker-N-image = 
+          let 
+            config = self.nixosConfigurations.k3s-worker-N;
+          in
+          if system == "x86_64-linux"
+          then config.config.system.build.isoImage
+          else nixpkgs.legacyPackages.${system}.runCommand "k3s-worker-N-image" {} ''
+            echo "This package can only be built on x86_64-linux systems"
+            exit 1
+          '';
+
+        k3s-worker-N-netboot-image = 
+          let 
+            config = self.nixosConfigurations.k3s-worker-N;
+          in
+          if system == "x86_64-linux"
+          then config.config.system.build.netbootIpxeScript
+          else nixpkgs.legacyPackages.${system}.runCommand "k3s-worker-N-image" {} ''
+            echo "This package can only be built on x86_64-linux systems"
+            exit 1
+          '';
       };
 
       # Dev shell is now per-system
@@ -395,6 +417,18 @@
           modules = [
             "${nixpkgs}/nixos/modules/virtualisation/proxmox-image.nix"
             ./modules/hosts/ucaia/zagato/k3s-nodes/worker-2.nix
+            sops-nix.nixosModules.sops
+          ];
+          specialArgs = { pkgs-unstable = mkPkgsUnstable "x86_64-linux"; };
+        };
+
+        # K3s Cluster Node N (Worker)
+        k3s-worker-N = nixpkgs.lib.nixosSystem {
+          system = "x86_64-linux";
+          modules = [
+            # "${nixpkgs}/nixos/modules/virtualisation/proxmox-image.nix"
+            "${nixpkgs}/nixos/modules/installer/netboot/netboot-minimal.nix"
+            ./modules/hosts/ucaia/zagato/k3s-nodes/worker-N.nix
             sops-nix.nixosModules.sops
           ];
           specialArgs = { pkgs-unstable = mkPkgsUnstable "x86_64-linux"; };

--- a/flake.nix
+++ b/flake.nix
@@ -547,7 +547,7 @@
         };
 
         zagato-master-01 = {
-          hostname = "10.0.4.201";
+          hostname = "10.0.20.11";
           sshUser = "erikp";
           profiles.system = {
             user = "root";
@@ -558,7 +558,7 @@
         };
 
         zagato-master-02 = {
-          hostname = "10.0.4.202";
+          hostname = "10.0.20.12";
           sshUser = "erikp";
           profiles.system = {
             user = "root";
@@ -569,7 +569,7 @@
         };
 
         zagato-master-03 = {
-          hostname = "10.0.4.203";
+          hostname = "10.0.20.13";
           sshUser = "erikp";
           profiles.system = {
             user = "root";
@@ -580,7 +580,7 @@
         };
 
         zagato-worker-01 = {
-          hostname = "10.0.4.204";
+          hostname = "10.0.20.14";
           sshUser = "erikp";
           profiles.system = {
             user = "root";
@@ -591,7 +591,7 @@
         };
 
         zagato-worker-02 = {
-          hostname = "10.0.4.205";
+          hostname = "10.0.20.15";
           sshUser = "erikp";
           profiles.system = {
             user = "root";

--- a/flake.nix
+++ b/flake.nix
@@ -580,7 +580,8 @@
         };
 
         zagato-worker-01 = {
-          hostname = "10.0.20.14";
+          # hostname = "10.0.20.14";
+          hostname = "10.0.4.214";
           sshUser = "erikp";
           profiles.system = {
             user = "root";

--- a/modules/hosts/gibraltar/bugatti-nix/main.nix
+++ b/modules/hosts/gibraltar/bugatti-nix/main.nix
@@ -16,7 +16,7 @@
   };
 
 
-  environment.systemPackages = with pkgs; [
+  environment.systemPackages = (with pkgs; [
     alejandra
     btop
     htop
@@ -40,7 +40,9 @@
     jq
     busybox
     neofetch
-  ];
+  ]) ++ ( with pkgs-unstable; [
+    claude-code
+  ]);
 
   boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
 

--- a/modules/hosts/ucaia/aspen/default.nix
+++ b/modules/hosts/ucaia/aspen/default.nix
@@ -1,0 +1,162 @@
+{
+  inputs,
+  outputs,
+  lib,
+  config,
+  pkgs,
+  pkgs-unstable,
+  ...
+}: let
+  hostName = "aspen";
+in {
+  networking.hostName = hostName;
+
+  proxmox = {
+    filenameSuffix = hostName;
+    qemuConf = {
+      name = hostName;
+      net0 = "virtio=6C:1C:2C:BC:6A:A4,bridge=vmbr1,firewall=0";
+    };
+  };
+
+  # Enable cloud-init network configuration
+  services.cloud-init.network.enable = true;
+
+  imports = [
+    ./services.nix
+    ./proxmox-settings.nix
+  ];
+
+  nix.settings = {
+    substituters = [
+      "https://cache.nixos.org?priority=1"
+      "https://nix-community.cachix.org?priority=2"
+      "https://cuda-maintainers.cachix.org?priority=3"
+      "https://numtide.cachix.org?priority=4"
+      "https://cache.flox.dev?priority=5"
+      "https://deploy-rs.cachix.org?priority=6"
+    ];
+
+    trusted-public-keys = [
+      "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+      "cuda-maintainers.cachix.org-1:0dq3bujKpuEPMCX6U4WylrUDZ9JyUG0VpVZa7CNfq5E="
+      "numtide.cachix.org-1:2ps1kLBUWjxIneOy1Ik6cQjb41X0iXVXeHigGmycPPE="
+      "flox-cache-public-1:7F4OyH7ZCnFhcze3fJdfyXYLQw/aV7GEed86nQ7IsOs="
+      "deploy-rs.cachix.org-1:xfNobmiwF/vzvK1gpfediPwpdIP0rpDV2rYqx40zdSI="
+    ];
+  };
+
+  environment.systemPackages = with pkgs; [
+    alejandra
+    btop
+    htop
+    tmux
+    git
+    tree
+    wget
+    inetutils
+    usbutils
+    pciutils
+    file
+    openssl
+    cachix
+    sops
+    nmap
+    jq
+    busybox
+    neofetch
+  ];
+
+  boot.tmp.cleanOnBoot = true;
+  security.polkit.enable = true;
+
+  services = {
+    openssh = {
+      enable = true;
+      settings = {
+        PasswordAuthentication = false;
+        PermitRootLogin = "no";
+      };
+    };
+
+  };
+
+  # Disable unnecessary services and features
+  services.pulseaudio.enable = false;
+  services.pipewire.enable = false;
+  hardware.bluetooth.enable = false;
+  services.xserver.enable = false;
+  services.printing.enable = false;
+  services.avahi.enable = false;
+
+  users.users.connorgolden = {
+    isNormalUser = true;
+    group = "users";
+    extraGroups = [ "wheel" ];
+    description = "Connor Golden";
+    hashedPassword =
+      "$6$e75Jf/dlhJJ.dF49$9vAbUWwYqrGqtT4I/T6ycHvEM6Z23n9Z3jKunoXwdBVS5rXhWW6VEGRohQCvltPS9lP8t0PL6bLMzWGIEAW.n/";
+    openssh.authorizedKeys.keys = [
+      "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDHnTKk78bO1hz+DkdeV3Tjcye+mxR58tgccQJzNOxfFefdRBagCMC6qtd2H/YUsWYSxzNpRWDadrBmXEIJ5h/YTMK9rD6gvvRnAUbtSnrsM8KQzaqohZ/Ouv1gkVicqe7MHag5ZiC8QDa8zIaHgqPalnEcj8v7mo7/+CcDdmECZ0bKi3m1oQK8nB4LJkGqv03aO/tdaRTa56nsbtRoqjSdkjT2tetgiA1+Ah65TbhkitMzQN3OVLoFEW4zdynxDDUuPpWajFefa/eGIQbfoQHwpqhSw6OZdBKhWlTLR2BQ0oofu49+kAUu7PLasaxArAeLWolX8CJHED36gsupay5XlipgxG8teBJ3EWffWc1fZ2c44gBlNlhPExC5Y6gLI6YnPSajnMsKJLySz2e52Cc3VdsLTaeAi+/7Pc/jH5yNeBvfjKP/VV8GD9ClDl3fNmSBAZawhml400OjaKel7scAJjygxKSHdpR9DQ2IphsKDd9a64cvIROX+kt4udeVhk8= connorgolden@FW-13"
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIENMEKtS2wB5NlWSAtsoKTss1B0UcD/TeDbMJgVdUKXJ"
+    ];
+  };
+
+  users.users.erikp = {
+    isNormalUser = true;
+    group = "users";
+    extraGroups = [ "wheel" ];
+    description = "Erik Parawell";
+    hashedPassword =
+      "$6$518O2ct8O/.dFXC3$oGwdfF4bgrojKTwE7guwAgtwUaoJAHDJ0IQbrNlahFz75cyaD4ZZ8UHtLFDvrK2v74gu/rErHZJ6W9lMSxQVW.";
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGvJ7EXvVEEar9mTg0Yy/hpsRisRtFPyKXHTpMNtigo7"
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKOPFxVGGxI4wBUu1SIgWE6Sr7CSBHNZebXDpSHITxC9"
+    ];
+  };
+
+  security.sudo.wheelNeedsPassword = false;
+
+  networking = {
+    nameservers = ["1.1.1.1" "8.8.4.4" "8.8.8.8" "9.9.9.9"];
+    firewall = {
+      enable = true;
+      allowedTCPPorts = [ 22 53 ];
+      allowedUDPPorts = [ 53 67 ];
+    };
+  };
+
+  # Select internationalisation properties.
+  i18n.defaultLocale = "en_US.UTF-8";
+
+  # Set your time zone.
+  time.timeZone = "America/Los_Angeles";
+
+  programs.nix-ld = {
+    enable = true;
+    package = pkgs.nix-ld-rs;
+  };
+
+  nix = {
+    gc = {
+      automatic = true;
+      dates = "weekly";
+      options = "--delete-older-than 7d";
+    };
+
+    settings = {
+      auto-optimise-store = true;
+      trusted-users = [ "root" "erikp" "connorgolden" ];
+      experimental-features = [ "flakes" "nix-command" ];
+    };
+  };
+
+  programs.mtr.enable = true;
+  programs.gnupg.agent = {
+    enable = true;
+    enableSSHSupport = true;
+  };
+
+  system.stateVersion = "24.05";
+}

--- a/modules/hosts/ucaia/aspen/proxmox-settings.nix
+++ b/modules/hosts/ucaia/aspen/proxmox-settings.nix
@@ -1,0 +1,28 @@
+{
+  inputs,
+  outputs,
+  lib,
+  config,
+  pkgs,
+  ...
+}: {  
+  # Set the disk size to 30GiB
+  virtualisation.diskSize = 30720;
+
+  proxmox = {
+    qemuConf = {
+      cores = 4;
+      memory = 4096;
+      virtio0 = "local-zfs:vm-9999-disk-0";
+    };
+  };
+
+  # File systems configuration for Proxmox VMs
+  fileSystems."/" = {
+    device = "/dev/disk/by-label/nixos";
+    autoResize = true;
+    fsType = "ext4";
+  };
+
+  boot.loader.grub.device = "/dev/vda";
+}

--- a/modules/hosts/ucaia/aspen/services.nix
+++ b/modules/hosts/ucaia/aspen/services.nix
@@ -12,10 +12,41 @@
       enable = true;
       settings = {
         interface = "eth0";
-        dhcp-range = "10.0.20.6,10.0.20.254,12h";
+
+        # Disable DNS server (port 53) - only do DHCP/TFTP
+        port = 0;
+        
+        # DHCP configuration
+        dhcp-range = "10.0.20.20,10.0.20.254,12h";
         dhcp-authoritative = true;
-        dhcp-option = "option:router,10.0.20.1";
-        # any PXE / Pixiecore lines here…
+
+        # TFTP configuration
+        enable-tftp = true;
+        tftp-root = "/srv/tftp";
+        tftp-secure = true;
+        
+        # PXE boot options
+        # Option 66: TFTP server name
+        dhcp-option = [
+          "option:router,10.0.20.1"
+          "option:dns-server,10.0.20.1"
+          "option:tftp-server,10.0.20.1"
+        ];
+        
+        # PXE boot filename (option 67)
+        dhcp-boot = "boot.ipxe";
+        
+        # Alternative: More specific PXE configuration
+        # You can also use conditional booting based on client architecture
+        # dhcp-match = "set:bios,option:client-arch,0";
+        # dhcp-match = "set:efi32,option:client-arch,6";
+        # dhcp-match = "set:efi64,option:client-arch,7";
+        # dhcp-match = "set:efi64,option:client-arch,9";
+        # dhcp-boot = [
+        #   "tag:bios,pxelinux.0"
+        #   "tag:efi32,bootia32.efi"
+        #   "tag:efi64,bootx64.efi"
+        # ];
       };
     };
 
@@ -23,11 +54,7 @@
       enable       = true;
       openFirewall = true;
       mode         = "boot";
-      quick        = "xyz";       # ignored in "boot" mode
-      dhcpNoBind   = true;        # leave DHCP to another server
-      # listen       = "10.0.20.2";
-      # port         = 8080;
-      # statusPort   = 9090;
+      dhcpNoBind   = true;
       kernel       = "/srv/tftp/bzImage";
       initrd       = "/srv/tftp/initrd";
       cmdLine      = "init=/init console=ttyS0,115200 netboot=true";
@@ -35,5 +62,20 @@
     };
   };
 
+  # Ensure TFTP directory exists and has proper permissions
+  system.activationScripts.tftp-setup = ''
+    mkdir -p /srv/tftp
+    chmod 755 /srv/tftp
+    chown -R dnsmasq:dnsmasq /srv/tftp
+  '';
 
+  # Open firewall ports for TFTP and DHCP
+  networking.firewall = {
+    allowedUDPPorts = [ 
+      67   # DHCP
+      68   # DHCP
+      69   # TFTP
+      4011 # PXE
+    ];
+  };
 }

--- a/modules/hosts/ucaia/aspen/services.nix
+++ b/modules/hosts/ucaia/aspen/services.nix
@@ -1,0 +1,39 @@
+{
+  inputs,
+  outputs,
+  lib,
+  config,
+  pkgs,
+  pkgs-unstable,
+  ...
+}: {
+  services = {
+    dnsmasq = {
+      enable = true;
+      settings = {
+        interface = "eth0";
+        dhcp-range = "10.0.20.6,10.0.20.254,12h";
+        dhcp-authoritative = true;
+        dhcp-option = "option:router,10.0.20.1";
+        # any PXE / Pixiecore lines here…
+      };
+    };
+
+    pixiecore = {
+      enable       = true;
+      openFirewall = true;
+      mode         = "boot";
+      quick        = "xyz";       # ignored in "boot" mode
+      dhcpNoBind   = true;        # leave DHCP to another server
+      # listen       = "10.0.20.2";
+      # port         = 8080;
+      # statusPort   = 9090;
+      kernel       = "/srv/tftp/bzImage";
+      initrd       = "/srv/tftp/initrd";
+      cmdLine      = "init=/init console=ttyS0,115200 netboot=true";
+      debug        = true;
+    };
+  };
+
+
+}

--- a/modules/hosts/ucaia/aspen/services.nix
+++ b/modules/hosts/ucaia/aspen/services.nix
@@ -60,6 +60,14 @@
       cmdLine      = "init=/init console=ttyS0,115200 netboot=true";
       debug        = true;
     };
+
+    nginx = {
+      enable = true;
+      virtualHosts."10.0.20.2" = {
+        root = "/srv/tftp";          # so /bzImage and /initrd are reachable
+        extraConfig = "autoindex on;";
+      };
+    };
   };
 
   # Ensure TFTP directory exists and has proper permissions
@@ -76,6 +84,9 @@
       68   # DHCP
       69   # TFTP
       4011 # PXE
+    ];
+    allowedTCPPorts = [
+      80   # HTTP
     ];
   };
 }

--- a/modules/hosts/ucaia/zagato/base-kube.nix
+++ b/modules/hosts/ucaia/zagato/base-kube.nix
@@ -20,6 +20,7 @@
 
   networking = {
     nameservers = ["10.0.4.12" "10.0.4.13" "1.1.1.1"];
+    nftables.enable = true;
     firewall = {
       enable = true;
       allowedTCPPorts = [
@@ -37,6 +38,13 @@
       allowedUDPPorts = [
         8472    # Flannel VXLAN
       ];
+      # vrrp is keepalived related
+      extraInputRules = ''
+        ip  protocol vrrp accept
+        ip6 nexthdr   vrrp accept
+        iifname "eth0" ip  protocol vrrp accept
+        iifname "eth0" ip6 nexthdr   vrrp accept
+      '';
     };
   };
 }

--- a/modules/hosts/ucaia/zagato/default.nix
+++ b/modules/hosts/ucaia/zagato/default.nix
@@ -82,6 +82,7 @@
     hashedPassword =
       "$6$e75Jf/dlhJJ.dF49$9vAbUWwYqrGqtT4I/T6ycHvEM6Z23n9Z3jKunoXwdBVS5rXhWW6VEGRohQCvltPS9lP8t0PL6bLMzWGIEAW.n/";
     openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIENMEKtS2wB5NlWSAtsoKTss1B0UcD/TeDbMJgVdUKXJ"
     ];
   };
   users.users.erikp = {

--- a/modules/hosts/ucaia/zagato/k3s-nodes/master-1.nix
+++ b/modules/hosts/ucaia/zagato/k3s-nodes/master-1.nix
@@ -49,11 +49,6 @@ in {
     clusterInit = true;
   };
 
-  # TFTP Server configuration
-  services.tftpd = {
-    enable = true;
-    path = "/srv/tftp";
-  };
 
   # Open ports needed for K3s
   networking.firewall = {

--- a/modules/hosts/ucaia/zagato/k3s-nodes/master-1.nix
+++ b/modules/hosts/ucaia/zagato/k3s-nodes/master-1.nix
@@ -19,7 +19,7 @@ in {
     filenameSuffix = hostName;
     qemuConf = {
       name = hostName;
-      net0 = "virtio=D8:D9:97:59:39:6A,bridge=vmbr0,firewall=1";
+      net0 = "virtio=D8:D9:97:59:39:6A,bridge=vmbr0,tag=20,firewall=1";
     };
   };
 

--- a/modules/hosts/ucaia/zagato/k3s-nodes/master-1.nix
+++ b/modules/hosts/ucaia/zagato/k3s-nodes/master-1.nix
@@ -13,7 +13,12 @@ in {
   imports = [
     ../default.nix
     ../proxmox-settings.nix
+    ../keepalived.nix
   ];
+
+services.keepalived.vrrpInstances.K3S_API = {
+  priority = 152;
+};
 
   proxmox = {
     filenameSuffix = hostName;

--- a/modules/hosts/ucaia/zagato/k3s-nodes/master-1.nix
+++ b/modules/hosts/ucaia/zagato/k3s-nodes/master-1.nix
@@ -49,6 +49,11 @@ in {
     clusterInit = true;
   };
 
+  # TFTP Server configuration
+  services.tftpd = {
+    enable = true;
+    path = "/srv/tftp";
+  };
 
   # Open ports needed for K3s
   networking.firewall = {

--- a/modules/hosts/ucaia/zagato/k3s-nodes/master-2.nix
+++ b/modules/hosts/ucaia/zagato/k3s-nodes/master-2.nix
@@ -46,7 +46,7 @@ in {
     enable = true;
     role = "server";
     tokenFile = config.sops.secrets.k3s-cluster-token.path;
-    serverAddr = "https://10.0.4.201:6443";
+    serverAddr = "https://10.0.20.11:6443";
   };
 
   # Open ports needed for K3s

--- a/modules/hosts/ucaia/zagato/k3s-nodes/master-2.nix
+++ b/modules/hosts/ucaia/zagato/k3s-nodes/master-2.nix
@@ -13,7 +13,12 @@ in {
   imports = [
     ../default.nix
     ../proxmox-settings.nix
+    ../keepalived.nix
   ];
+
+  services.keepalived.vrrpInstances.K3S_API = {
+    priority = 151;
+  };
 
   proxmox = {
     filenameSuffix = hostName;

--- a/modules/hosts/ucaia/zagato/k3s-nodes/master-2.nix
+++ b/modules/hosts/ucaia/zagato/k3s-nodes/master-2.nix
@@ -19,7 +19,7 @@ in {
     filenameSuffix = hostName;
     qemuConf = {
       name = hostName;
-      net0 = "virtio=B4:03:04:16:43:CB,bridge=vmbr0,firewall=1";
+      net0 = "virtio=B4:03:04:16:43:CB,bridge=vmbr0,tag=20,firewall=1";
     };
   };
 

--- a/modules/hosts/ucaia/zagato/k3s-nodes/master-3.nix
+++ b/modules/hosts/ucaia/zagato/k3s-nodes/master-3.nix
@@ -46,7 +46,7 @@ in {
     enable = true;
     role = "server";
     tokenFile = config.sops.secrets.k3s-cluster-token.path;
-    serverAddr = "https://10.0.4.201:6443";
+    serverAddr = "https://10.0.20.11:6443";
   };
 
   # Open ports needed for K3s

--- a/modules/hosts/ucaia/zagato/k3s-nodes/master-3.nix
+++ b/modules/hosts/ucaia/zagato/k3s-nodes/master-3.nix
@@ -13,7 +13,12 @@ in {
   imports = [
     ../default.nix
     ../proxmox-settings.nix
+    ../keepalived.nix
   ];
+
+  services.keepalived.vrrpInstances.K3S_API = {
+    priority = 150;
+  };
 
   proxmox = {
     filenameSuffix = hostName;

--- a/modules/hosts/ucaia/zagato/k3s-nodes/master-3.nix
+++ b/modules/hosts/ucaia/zagato/k3s-nodes/master-3.nix
@@ -19,7 +19,7 @@ in {
     filenameSuffix = hostName;
     qemuConf = {
       name = hostName;
-      net0 = "virtio=54:CE:57:C4:5F:08,bridge=vmbr0,firewall=1";
+      net0 = "virtio=54:CE:57:C4:5F:08,bridge=vmbr0,tag=20,firewall=1";
     };
   };
 

--- a/modules/hosts/ucaia/zagato/k3s-nodes/worker-1.nix
+++ b/modules/hosts/ucaia/zagato/k3s-nodes/worker-1.nix
@@ -19,11 +19,12 @@ in {
     filenameSuffix = hostName;
     qemuConf = {
       name = hostName;
-      net0 = "virtio=D2:A8:F3:12:B9:E4,bridge=vmbr0,firewall=1";
+      net0 = "virtio=D2:A8:F3:12:B9:E4,bridge=vmbr0,tag=20,firewall=1";
     };
   };
 
   # Enable cloud-init network configuration
+  services.cloud-init.enable = true;
   services.cloud-init.network.enable = true;
 
   # Enable userborn service (triggers useSystemdActivation in sops-nix)

--- a/modules/hosts/ucaia/zagato/k3s-nodes/worker-1.nix
+++ b/modules/hosts/ucaia/zagato/k3s-nodes/worker-1.nix
@@ -73,7 +73,7 @@ in {
     enable = true;
     role = "agent";
     tokenFile = config.sops.secrets.k3s-cluster-token.path;
-    serverAddr = "https://10.0.4.201:6443"; # Address of the first server
+    serverAddr = "https://10.0.20.11:6443"; # Address of the first server
   };
 
   # Ensure K3s waits for the key extraction

--- a/modules/hosts/ucaia/zagato/k3s-nodes/worker-1.nix
+++ b/modules/hosts/ucaia/zagato/k3s-nodes/worker-1.nix
@@ -30,7 +30,7 @@ in {
   sops = {
     defaultSopsFile = ../../../../../secrets/hosts/ucaia/zagato/k3s-secrets.yaml;
     defaultSopsFormat = "yaml";
-    age.keyFile = "/run/age/age.key";
+    age.keyFile = "/var/lib/sops-nix/key.txt";
     age.generateKey = false;
     secrets = {
       k3s-cluster-token = {
@@ -57,19 +57,34 @@ in {
     # You can override or extend any of the structured settings here.
     {
       bootcmd = [
-        # 1) create the dir on the tmpfs
-        "mkdir -p /run/age"
+        # 1) create the persistent directory
+        "mkdir -p /var/lib/sops-nix"
 
         # 2) pull 'age_key' out of your meta-data snippet
-        "sh -c 'cloud-init query -f \"{{ ds.meta_data.age_key }}\" > /run/age/age.key'"
-      ];
-
-      runcmd = [
-        # 3) lock it down
-        "chmod 0400 /run/age/age.key"
+        "sh -c 'cloud-init query -f \"{{ ds.meta_data.age_key }}\" > /var/lib/sops-nix/key.txt'"
+        
+        # 3) set proper permissions
+        "chmod 600 /var/lib/sops-nix/key.txt"
       ];
     }
   ];
+
+  # Systemd service to ensure cloud-init completes before SOPS services
+  systemd.services.sops-key-provision = {
+    description = "Wait for cloud-init and provision SOPS keys";
+    after = [ "cloud-init.target" ];
+    wants = [ "cloud-init.target" ];
+    
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      ExecStartPre = "${pkgs.cloud-init}/bin/cloud-init status --wait";
+      ExecStart = "${pkgs.bash}/bin/bash -c 'while [ ! -f /var/lib/sops-nix/key.txt ]; do sleep 1; done'";
+      TimeoutStartSec = 300;
+    };
+    
+    wantedBy = [ "multi-user.target" ];
+  };
 
   # K3s configuration for a worker node
   services.k3s = {
@@ -77,6 +92,18 @@ in {
     role = "agent";
     tokenFile = config.sops.secrets.k3s-cluster-token.path;
     serverAddr = "https://10.0.4.201:6443"; # Address of the first server
+  };
+
+  # Ensure K3s waits for the key provisioning
+  systemd.services.k3s = {
+    after = [ "sops-key-provision.service" ];
+    wants = [ "sops-key-provision.service" ];
+  };
+
+  # Make SOPS secrets depend on the key provisioning service
+  systemd.services.sops-install-secrets = {
+    after = [ "sops-key-provision.service" ];
+    wants = [ "sops-key-provision.service" ];
   };
 
   # Open ports needed for K3s worker node

--- a/modules/hosts/ucaia/zagato/k3s-nodes/worker-1.nix
+++ b/modules/hosts/ucaia/zagato/k3s-nodes/worker-1.nix
@@ -26,6 +26,9 @@ in {
   # Enable cloud-init network configuration
   services.cloud-init.network.enable = true;
 
+  # Enable userborn service (triggers useSystemdActivation in sops-nix)
+  services.userborn.enable = true;
+
   # SOPS configuration
   sops = {
     defaultSopsFile = ../../../../../secrets/hosts/ucaia/zagato/k3s-secrets.yaml;
@@ -40,50 +43,29 @@ in {
     };
   };
 
-  systemd.services.cloud-init = {
-    unitConfig = {
-      # Don't let cloud-init failure affect other services
-      StartLimitBurst = 0;
-    };
-    serviceConfig = {
-      # Make the service succeed even if cloud-init exits with code 1
-      SuccessExitStatus = [ 0 1 ];
-    };
-  };
-
-  # inject *only* your Age-key logic; everything else (hostname, SSH keys,
-  # filesystem resize, modules, etc.) is handled by the module’s defaults
-  services.cloud-init.settings = lib.mkMerge [
-    # You can override or extend any of the structured settings here.
-    {
-      bootcmd = [
-        # 1) create the persistent directory
-        "mkdir -p /var/lib/sops-nix"
-
-        # 2) pull 'age_key' out of your meta-data snippet
-        "sh -c 'cloud-init query -f \"{{ ds.meta_data.age_key }}\" > /var/lib/sops-nix/key.txt'"
-        
-        # 3) set proper permissions
-        "chmod 600 /var/lib/sops-nix/key.txt"
-      ];
-    }
-  ];
-
-  # Systemd service to ensure cloud-init completes before SOPS services
-  systemd.services.sops-key-provision = {
-    description = "Wait for cloud-init and provision SOPS keys";
-    after = [ "cloud-init.target" ];
-    wants = [ "cloud-init.target" ];
+  # Extract SOPS age key from cloud-init metadata
+  systemd.services.sops-extract-key = {
+    description = "Extract SOPS age key from cloud-init";
+    wantedBy = [ "sysinit.target" ];
+    after = [ "cloud-final.service" ];
+    wants = [ "cloud-final.service" ];
     
     serviceConfig = {
       Type = "oneshot";
       RemainAfterExit = true;
-      ExecStartPre = "${pkgs.cloud-init}/bin/cloud-init status --wait";
-      ExecStart = "${pkgs.bash}/bin/bash -c 'while [ ! -f /var/lib/sops-nix/key.txt ]; do sleep 1; done'";
-      TimeoutStartSec = 300;
     };
     
-    wantedBy = [ "multi-user.target" ];
+    script = ''
+      # Wait for cloud-init to complete all phases
+      ${pkgs.cloud-init}/bin/cloud-init status --wait
+      
+      if [ ! -f /var/lib/sops-nix/key.txt ]; then
+        mkdir -p /var/lib/sops-nix
+        ${pkgs.cloud-init}/bin/cloud-init query -f "{{ ds.meta_data.age_key }}" > /var/lib/sops-nix/key.txt
+        chmod 600 /var/lib/sops-nix/key.txt
+        echo "Age key extracted from cloud-init"
+      fi
+    '';
   };
 
   # K3s configuration for a worker node
@@ -94,16 +76,16 @@ in {
     serverAddr = "https://10.0.4.201:6443"; # Address of the first server
   };
 
-  # Ensure K3s waits for the key provisioning
+  # Ensure K3s waits for the key extraction
   systemd.services.k3s = {
-    after = [ "sops-key-provision.service" ];
-    wants = [ "sops-key-provision.service" ];
+    after = [ "sops-extract-key.service" ];
+    wants = [ "sops-extract-key.service" ];
   };
 
-  # Make SOPS secrets depend on the key provisioning service
+  # Make SOPS secrets depend on the key extraction service
   systemd.services.sops-install-secrets = {
-    after = [ "sops-key-provision.service" ];
-    wants = [ "sops-key-provision.service" ];
+    after = [ "sops-extract-key.service" ];
+    requires = [ "sops-extract-key.service" ];
   };
 
   # Open ports needed for K3s worker node

--- a/modules/hosts/ucaia/zagato/k3s-nodes/worker-2.nix
+++ b/modules/hosts/ucaia/zagato/k3s-nodes/worker-2.nix
@@ -19,11 +19,12 @@ in {
     filenameSuffix = hostName;
     qemuConf = {
       name = hostName;
-      net0 = "virtio=D2:53:71:45:AB:7B,bridge=vmbr0,firewall=1";
+      net0 = "virtio=D2:53:71:45:AB:7B,bridge=vmbr0,tag=20,firewall=1";
     };
   };
 
   # Enable cloud-init network configuration
+  services.cloud-init.enable = true;
   services.cloud-init.network.enable = true;
 
   # Enable userborn service (triggers useSystemdActivation in sops-nix)

--- a/modules/hosts/ucaia/zagato/k3s-nodes/worker-2.nix
+++ b/modules/hosts/ucaia/zagato/k3s-nodes/worker-2.nix
@@ -73,7 +73,7 @@ in {
     enable = true;
     role = "agent";
     tokenFile = config.sops.secrets.k3s-cluster-token.path;
-    serverAddr = "https://10.0.4.201:6443"; # Address of the first server
+    serverAddr = "https://10.0.20.11:6443"; # Address of the first server
   };
 
   # Ensure K3s waits for the key extraction

--- a/modules/hosts/ucaia/zagato/k3s-nodes/worker-2.nix
+++ b/modules/hosts/ucaia/zagato/k3s-nodes/worker-2.nix
@@ -30,7 +30,7 @@ in {
   sops = {
     defaultSopsFile = ../../../../../secrets/hosts/ucaia/zagato/k3s-secrets.yaml;
     defaultSopsFormat = "yaml";
-    age.keyFile = "/run/age/age.key";
+    age.keyFile = "/var/lib/sops-nix/key.txt";
     age.generateKey = false;
     secrets = {
       k3s-cluster-token = {
@@ -46,19 +46,34 @@ in {
     # You can override or extend any of the structured settings here.
     {
       bootcmd = [
-        # 1) create the dir on the tmpfs
-        "mkdir -p /run/age"
+        # 1) create the persistent directory
+        "mkdir -p /var/lib/sops-nix"
 
         # 2) pull 'age_key' out of your meta-data snippet
-        "sh -c 'cloud-init query -f \"{{ ds.meta_data.age_key }}\" > /run/age/age.key'"
-      ];
-
-      runcmd = [
-        # 3) lock it down
-        "chmod 0400 /run/age/age.key"
+        "sh -c 'cloud-init query -f \"{{ ds.meta_data.age_key }}\" > /var/lib/sops-nix/key.txt'"
+        
+        # 3) set proper permissions
+        "chmod 600 /var/lib/sops-nix/key.txt"
       ];
     }
   ];
+
+  # Systemd service to ensure cloud-init completes before SOPS services
+  systemd.services.sops-key-provision = {
+    description = "Wait for cloud-init and provision SOPS keys";
+    after = [ "cloud-init.target" ];
+    wants = [ "cloud-init.target" ];
+    
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      ExecStartPre = "${pkgs.cloud-init}/bin/cloud-init status --wait";
+      ExecStart = "${pkgs.bash}/bin/bash -c 'while [ ! -f /var/lib/sops-nix/key.txt ]; do sleep 1; done'";
+      TimeoutStartSec = 300;
+    };
+    
+    wantedBy = [ "multi-user.target" ];
+  };
 
   # K3s configuration for a worker node
   services.k3s = {
@@ -66,6 +81,18 @@ in {
     role = "agent";
     tokenFile = config.sops.secrets.k3s-cluster-token.path;
     serverAddr = "https://10.0.4.201:6443"; # Address of the first server
+  };
+
+  # Ensure K3s waits for the key provisioning
+  systemd.services.k3s = {
+    after = [ "sops-key-provision.service" ];
+    wants = [ "sops-key-provision.service" ];
+  };
+
+  # Make SOPS secrets depend on the key provisioning service
+  systemd.services.sops-install-secrets = {
+    after = [ "sops-key-provision.service" ];
+    wants = [ "sops-key-provision.service" ];
   };
 
   # Open ports needed for K3s worker node

--- a/modules/hosts/ucaia/zagato/k3s-nodes/worker-N.nix
+++ b/modules/hosts/ucaia/zagato/k3s-nodes/worker-N.nix
@@ -62,7 +62,7 @@ in {
     enable = true;
     role = "agent";
     tokenFile = "/run/k3s/token";
-    serverAddr = "https://10.0.4.201:6443"; # Address of the first server
+    serverAddr = "https://10.0.20.11:6443"; # Address of the first server
   };
 
   # Open ports needed for K3s worker node

--- a/modules/hosts/ucaia/zagato/k3s-nodes/worker-N.nix
+++ b/modules/hosts/ucaia/zagato/k3s-nodes/worker-N.nix
@@ -10,8 +10,9 @@
 let
   fsLabel    = "containerd";
   mountPoint = "/var/lib/rancher/k3s/agent/containerd";
-  diskById   = "/dev/disk/by-id/scsi-QEMU_QEMU_HARDDISK_CONTAINERD01";
-  devUnit    = "dev-disk-by\\x2did-scsi\\x2dQEMU_QEMU_HARDDISK_CONTAINERD01.device";
+  diskId     = "scsi-0QEMU_QEMU_HARDDISK_CONTAINERD01";
+  diskById   = "/dev/disk/by-id/${diskId}";
+  devUnit    = "dev-disk-by\\x2did-${lib.replaceStrings ["-"] ["\\x2d"] diskId}.device";
 in {
   imports = [
     ../default.nix

--- a/modules/hosts/ucaia/zagato/k3s-nodes/worker-N.nix
+++ b/modules/hosts/ucaia/zagato/k3s-nodes/worker-N.nix
@@ -32,6 +32,37 @@ in {
   # Disable the static hostname generation
   networking.hostName = lib.mkForce "";
 
+  # Disable console autologin from netboot-minimal defaults
+  services.getty.autologinUser = lib.mkForce null;
+
+  users = {
+    mutableUsers = false;
+    users = {
+      root = {
+        hashedPassword =
+          "$6$518O2ct8O/.dFXC3$oGwdfF4bgrojKTwE7guwAgtwUaoJAHDJ0IQbrNlahFz75cyaD4ZZ8UHtLFDvrK2v74gu/rErHZJ6W9lMSxQVW.";
+      };
+      kubeadmin = {
+        isNormalUser = true;
+        group = "users";
+        extraGroups = [ "wheel" ];
+        description = "Kubernetes Administrator";
+        hashedPassword =
+          "$6$518O2ct8O/.dFXC3$oGwdfF4bgrojKTwE7guwAgtwUaoJAHDJ0IQbrNlahFz75cyaD4ZZ8UHtLFDvrK2v74gu/rErHZJ6W9lMSxQVW.";
+        openssh.authorizedKeys.keys = [
+          "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGvJ7EXvVEEar9mTg0Yy/hpsRisRtFPyKXHTpMNtigo7"
+          "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKOPFxVGGxI4wBUu1SIgWE6Sr7CSBHNZebXDpSHITxC9"
+          "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIENMEKtS2wB5NlWSAtsoKTss1B0UcD/TeDbMJgVdUKXJ"
+        ];
+      };
+      # Lock the temporary installer account so it cannot be used
+      nixos = lib.mkForce {
+        isNormalUser = true;
+        hashedPassword = "!";
+      };
+    };
+  };
+
   systemd.tmpfiles.rules = [ "d ${mountPoint} 0755 root root -" ];
 
   systemd.services.mkfs-containerd = {

--- a/modules/hosts/ucaia/zagato/k3s-nodes/worker-N.nix
+++ b/modules/hosts/ucaia/zagato/k3s-nodes/worker-N.nix
@@ -1,0 +1,77 @@
+{
+  inputs,
+  outputs,
+  lib,
+  config,
+  pkgs,
+  pkgs-unstable,
+  ...
+}:
+let
+
+in {
+  imports = [
+    ../default.nix
+  ];
+
+  # Cloud init and proxmox integration
+  networking.useNetworkd = true;
+  services = {
+    cloud-init = {
+      enable = true;
+      network.enable = true;
+    };
+    sshd.enable = true;
+    qemuGuest.enable = true;
+  };
+
+  # # SOPS configuration
+  # sops = {
+  #   defaultSopsFile = ../../../../../secrets/hosts/ucaia/zagato/k3s-secrets.yaml;
+  #   defaultSopsFormat = "yaml";
+  #   age.keyFile = "/run/age/age.key";
+  #   age.generateKey = false;
+  #   secrets = {
+  #     k3s-cluster-token = {
+  #       mode = "0400";
+  #       restartUnits = [ "k3s.service" ];
+  #     };
+  #   };
+  # };
+
+  services.cloud-init.settings = lib.mkMerge [
+    # You can override or extend any of the structured settings here.
+    {
+      bootcmd = [
+        # 1) create the dir on the tmpfs
+        "mkdir -p /run/k3s"
+
+        # 2) pull 'age_key' out of your meta-data snippet
+        "sh -c 'cloud-init query -f \"{{ ds.meta_data.age_key }}\" > /run/k3s/token'"
+      ];
+
+      runcmd = [
+        # 3) lock it down
+        "chmod 0400 /run/k3s/token"
+      ];
+    }
+  ];
+
+  # K3s configuration for a worker node
+  services.k3s = {
+    enable = true;
+    role = "agent";
+    tokenFile = "/run/k3s/token";
+    serverAddr = "https://10.0.4.201:6443"; # Address of the first server
+  };
+
+  # Open ports needed for K3s worker node
+  networking.firewall = {
+    allowedTCPPorts = [
+      10250   # Kubelet API
+    ];
+    allowedUDPPorts = [
+      8472    # Flannel VXLAN
+    ];
+  };
+}

--- a/modules/hosts/ucaia/zagato/keepalived.nix
+++ b/modules/hosts/ucaia/zagato/keepalived.nix
@@ -1,0 +1,50 @@
+{ config, pkgs, lib, ... }:
+let
+  k3sReadyzScript = pkgs.writeShellScriptBin "k3s-readyz-check" ''
+    #!/bin/sh
+    exec ${pkgs.curl}/bin/curl --silent --fail \
+      --cacert /var/lib/rancher/k3s/server/tls/server-ca.crt \
+      --cert   /var/lib/rancher/k3s/server/tls/client-admin.crt \
+      --key    /var/lib/rancher/k3s/server/tls/client-admin.key \
+      https://127.0.0.1:6443/readyz >/dev/null
+  '';
+in {
+  services.keepalived = {
+    enable = true;
+
+    extraGlobalDefs = ''
+      use_symlink_paths true
+      script_user root
+      enable_script_security
+      max_auto_priority
+    '';
+
+    vrrpScripts = {
+      chk_apiserver = {
+        script   = "${k3sReadyzScript}/bin/k3s-readyz-check";
+        interval = 2;
+        timeout  = 1;
+        rise     = 2;
+        fall     = 2;
+        user     = "root";
+      };
+    };
+
+    vrrpInstances = {
+      K3S_API = {
+        state = "BACKUP";
+        interface = "eth0";
+        virtualRouterId = 51;
+        # priority = 150; # Can be set individually on nodes
+        virtualIps = [ { addr = "10.0.20.5/24"; } ];
+        trackScripts = [ "chk_apiserver" ];
+
+        # Put keepalived directives not modeled by the module here
+        extraConfig = ''
+          advert_int 1
+          preempt_delay 5
+        '';
+      };
+    };
+  };
+}

--- a/secrets/hosts/gibraltar/bugatti-nix-secrets.yaml
+++ b/secrets/hosts/gibraltar/bugatti-nix-secrets.yaml
@@ -5,38 +5,38 @@ sops:
         - recipient: age1q3575mlegx4mzxtmzey5rzg9nwrnwlc9mlr5jeqcfltnzt6gwcqq6jdrka
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwS0JXYWF1Y0xwOFJ1T1ov
-            QnN1UWZGQnFzTXJBa0lQeUNqTytoSDNldWxnCmJtSEtnYml6ODF2a3plYmQ2Mi8x
-            V2RHUlRHNGdjWjRQV2J0SmRhL2VoeGsKLS0tIGJ1Z0h3eXhiVXZTSnFFMTZwa1J5
-            VWovdUtwK2VMMjV5eWQrc1hiZmJyUWsKj77rOjT5J9eHeWJaRHJzrJKQoxfC8Mxi
-            KISSEouNNYND1ozfXCo/CCunU4BtCTN+UKpOxH96QQaQfl5SzZvyXQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1SmhYay9pZlNwSUJiY1RT
+            TDlxZDJ1Mkhob3NEdWZhWmZ2YjVaNkl2bERZCjJIT250SHp2TDZsM1AyM2FlK3J6
+            QWJad3huOG1vRnZVeUhrZnNHalFMZG8KLS0tIG14RUpxV0Y3cnNjVXdyaGRzZVpp
+            VkVKWm80d1VWZ2ZpV2VXQ0pabEZkMXcK7vZ/9V9tzrpYrTlcN5ceHgynE3t3C+S8
+            8Nllf0weksOfsiTlMalvDhh99gukyYyhGMml+5nYAjs3wBs+OPMN0Q==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age17fq29yexw9rf30je5xp86hdda6tgug52sax7vy0af2sngempqv0qwhe4vr
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzVlFZMnJZcTRNNjBzZzd2
-            bG5NOXI0b05vRURxMzlJUEc1elVibTJnQWpRCnNndWlKa3JQcGlrS1RPSHRBZ1I0
-            UkwyQzZEWlA0ZzUzVVJiMlAwS2pYc2MKLS0tIHVqejRjVk15c3dJOFBnSEdwbjg1
-            bmpYVFRHMFY3VzhSUGNqQWZJZThSNHcKZMd6htqaFhxmk4wwI56KNtc/PQMbiNqE
-            CBe7yQfjwAheU6O0hcV5BTUBF+0fGIOkba19imTG5s4VryCd8xlhZQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwbWptNUtkT254MzNLdjlG
+            YU9sa1NRQTNpWktaRzcyYk9iR2dnYVNlaHg0Ck9JT3hBOEhkQ3NaSDZBM2NUZXJ5
+            b0RaNXNUamE2eDZVUURDZVRacDZwcncKLS0tIGVRaW0wS0thU1Z6Mmt6S1BZc0pM
+            ay9VVVphMnZmaHFENDFhdTE4dE5DM00KJxaWTTS4FZollp5943fvdqhsNScDAX0F
+            mdFtyXIZHAG+F7MiGMSZjKRgvwZlo1zx88tEiQKfKkArJf6VMWMaZw==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1tpupgevxd2d50zv95c098c3xkfqed4zk46h8fag9stadj75dvu0q3wx0mk
+        - recipient: age1wcuzeqxgdmv6ev0ufawnu699pyxrqq565tae79sa2jfgnffvlvmq5xd03h
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKMEI5VzJBZ3FQenYyWG9Y
-            V3NITkR4RmxGRFFHQllUU1hHNlNQb2lmOFRrCnNuYWtaZ3VxVVdROWxLbExQejhU
-            bFYwS1ZaZHF5SlJ4Y3F2M3dlVGh1V28KLS0tIGxDSEZ0Q2ZaTkRSVjhyQWtBZTNt
-            Uy9GVjFHdzRObHBuT0pnSmtpVzNRUHcKGf9IIx2zhw0xX2kprtaAUu9SjI6YuIrM
-            UrQ4u3GRPHMPhMJLykuDawY2Yr6LbjNmLCiiO1YEFqzrQu2wYQxobg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmYVNycVFER1h1cEx0Z05T
+            Umk3Q3hsbXlxQlRSbEV1cXlPd1pwOXZpV2lVCjQyU3BRd1RDTXJ3c2RmVkFXb2s3
+            SHRmV1pkSy9Fdm1Xdnp3NUdzdVhOMUUKLS0tIGczdExPL1dqbEhnOVdERXgyS1hr
+            aEgrcjFkRkZzNlhaZ1ZVNndPNkZ2a0UK7pk+nS6qGMXexc8H1TTmwzdUrqs1Dvjw
+            zmsMFeDiZPtjKPui16Xo/4AMizXZ/3FWteEKDjylNPte9nYHArR15Q==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1wj8d6dpv8xt5m2kpusxzfkfuedp5j4qjszrtg0tnzevgkd3sla8q0wms67
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVbUd5RmhzdUY3OHJDOCt6
-            ZHZGaUh4UFRTR1Zzdlk4dGwwV2dWcFpsTjI0Ck1xcjNOb09KNktjREJrNTN4eGJh
-            akZZa2pKcFNHbVNuQ0pOQi9uMUU0MzgKLS0tIGI2d0l6aWh1WE9US0Y3VCtnYmFP
-            elpJNG51b2lWdFQ0MHZWa0hhcGtKMU0KpUuwSJKIjFB2Hh1o7fLiDr6JjU7XS1NW
-            +/kh76n87QgbGs5EREkNxylXSGDD2d61COQy/46Em3+fnLQ6vr4/jA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBROWVYMUg4NGgzZThQY2c3
+            MlZhbzRMZHdBVVo1UEtjOUg1ZVZuZHJaQ0ZZCmZkSXhvNE5JZXlBNHFFK25IY1NB
+            MEJaMm1VWWJpUEo1K2k4N24ySzJnUjQKLS0tIFNFM2tRMmZUV2NHSjhDWHpyTmgw
+            dFQ2NStackkwWGRPVjBIcWp0eHNMeEUKuovbH72ToD9ISTNrOspg27GamWUO2Etd
+            WJ/iQmolO/pAf/T8EzOFB+QOz3Gn/nhc8V9jFSt+pr8M60YNzSSrxw==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2025-03-02T00:21:07Z"
     mac: ENC[AES256_GCM,data:62scjCzunAyRMeZ7X1mnGjEZ10KqmlHb6kmdBp03bSUXZoVmh1o2d5TCaJsSv2f86PFEcCPRRkkCMKUPCI2OH8I7/n2+P9Yz9QynBL1VTez7cndXpOXFTlQ9dxQQw3QV5FTD98jAMIcSGt/Z5B89FclYBDSwOarm21M5Cql+avs=,iv:YPfEG6QukwMezw8Lnk5YBb4vfgdHTJ0xT66qf8yoC6w=,tag:YUFji6HX5sqXnqxdQO5wTw==,type:str]

--- a/secrets/hosts/oracle-cloud/free-aarch64.yaml
+++ b/secrets/hosts/oracle-cloud/free-aarch64.yaml
@@ -5,38 +5,38 @@ sops:
         - recipient: age1hj5dyl0wzlq92ms2hrut6he05dqv0pknlv7wpyv2jywhz2hqwe9qgpt5dl
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByTUFRWTRSTGdaQ0E3czh4
-            Ti9SQmRZQVpqSE4xd29uaC9xcFphSjFOeVdnCk4rakNVQ1ZCMDhoOEZhVmwxZHFW
-            MW5yRFdsQVJBcmpmVEZIdUtVL3lRMzAKLS0tIFhOdWRITXplaUEwTjN6UWFLd1FW
-            dyt2UUc2cHcrblJnaWYzNUFtZ0NncW8KdFhTLQ8rKtfQ54PF1fYZqXP5iXFqIpvX
-            kmiu4McnY7oeST4imU33/QKNMXWvbBvxymJvMN38Hw5Ad+6Rqd1QLg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzSmthZ0daVlRnNzJoNDQ4
+            aWM2cm8vcFo5QTVVNXB4d1RSUVF3VEFnU1ZzCnJ1ZzBRaEl0R2hyeGU2K09XMVFF
+            ckxLWVlBcGdVOTVnUWpqaGZiUmZNelkKLS0tIEtSWXBuQVNSVzZlTncyVDNGMlA3
+            UHViZnluZ1ZUUmdDYkVRNFBmM01Vb3cKSIcxaSw90d6rew6YjKU0Vd2Lu596BsgA
+            aCXpcYWcL2axhVToJjpm1pU7P4rqK5Rht6+O+OrXQFCUbkK5YyCOBg==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age17fq29yexw9rf30je5xp86hdda6tgug52sax7vy0af2sngempqv0qwhe4vr
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6bkpNWnpmY1NhWXRWN0hH
-            VFQ2UE9JdmZXdFpLaVYyYjNFT0prbmtzVm5VCllDZTBKY3lQVTBxcmZTaXl0N3Yx
-            cFNKeFhrc0ZmM0dKQ3hzQmZVZTFlNlUKLS0tIEp1MHRTQkptNk5GWCtIaFh3alNZ
-            aU54R211WkxiSzNNWWRwcnVaTHRPK1EK0TLf9HNYjWwC5Uhsp8bQ+5nuMLzZeT9N
-            8srP06u9GPsUDTORXFz/1XBHFyzwwuxDpjDWavQX2+AGhNQT2Xcxzg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSOHpnTGljbEhDL3RIdVcz
+            dHcraHptMXNiTXpxVDlORWJCZHNUWG95emd3CmVNL1ppYTFOeXdUQ1FsQk5JWmd0
+            RGtnRlVPWm9WNU1JU0dkN2YwYjlZaVUKLS0tICtTT2EvUml2dGRTWk9JVzFkSlkx
+            YWE4VkM3ZnhqaG1SdXFGQWFwdkk4ZkUKKxPwjrBLELqfewzfqMzO0szvFeevXtbH
+            DENGLMIJEcEdkBONBTdxQSdVxRbFNn8CzNf8c9ohaHIFOiU4FF9qrw==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1tpupgevxd2d50zv95c098c3xkfqed4zk46h8fag9stadj75dvu0q3wx0mk
+        - recipient: age1wcuzeqxgdmv6ev0ufawnu699pyxrqq565tae79sa2jfgnffvlvmq5xd03h
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFNEg0dXZlSmdDOEpxdEMz
-            aHdnVVpaSWRDdytoeGI4ajZZQTBweDNKVjBBCjd5ZUlSQzJPTVQ5WnE0TzdSTEJD
-            MmJwcjJnZEs5Qzl3YXozZTVNeGQ3cjgKLS0tIEFSNzZvNmRwUitvaW9MbGdYSVhR
-            c3NOZXFZOWRuVWhFSWNWOE1oYXROTDQKeXEaPefsqn94syAWdmD3dJyrE1+Wfm9u
-            CoIjzl5vky5MIilZJNNkS8IoAsL4UOs2yvSMUqIqWYmsAfegiUIOXg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRVFpyVmg3WW1iNGs2SnJR
+            ZWZYTTl6UjlHVXdHNFZiU0R6RzB4M1BCcUFVCmxaYUxvVC9QeVB0ZEZYOGpYcG04
+            c1NyYkRjQ00vM2RsVVpmUjdCVFZZNjgKLS0tIEpFRDhIY25ubFk2RTdkbWovZGF3
+            Vmo2NURZTXJDQzRCZ2tvd0doWmw0dncKOZkpu/gOyb82EArBLooXSRE7mE+R5g0Y
+            h2DHBUXHGliw0m/s67/uAzaw42NfPPP/UoRuC/AF+ayLJnD0nammjQ==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1wj8d6dpv8xt5m2kpusxzfkfuedp5j4qjszrtg0tnzevgkd3sla8q0wms67
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSNEhxQnZEYmREQlB6Q1NF
-            SkNiVUxUU3htNXVaQXFOenp6bjdyTTBJQXhnCmFQNlRpOFAwMnNsM2tCOFBId1pL
-            anpZSVBxUitZeTJvMWZrS2c5WWVHSWcKLS0tIE9sazMvTFVtdnlOUWl2aGNmRHJH
-            aVU0a3k2WGFFQjdRL21aeXdoOU1ic2sKbwyj8/lTJdxk6Rgc7la3Gpmqg8HrJ1X1
-            Fj0tle7pgieqLVVbGhf/LkBRD9cjP9dXtFsJjo8oFxVSriQ4Eq08Lw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0SGpDRlBWWGJ1MXlPRWhJ
+            MGpHcUlxQmk1bVdLZ2pRZ2tCNGIzdGI5K0I0CmtDam9CZXZzVHZoUmc2cXp5SGpy
+            Mi9UMXAxUEpiYVVnOTNaYTFhR1pOUkUKLS0tIGkwYkVHb0J2dS83ZEZ6NnlEMXN3
+            RzBXNTNPTzlIREJ2T2w0Zk4wcldINUkKREKdASAJCIu6zTTEiI9oMa4XBa88nOf3
+            OzFsijFALh7x55c0O15Vr66iYDLdfRPvhgkhYueAvc1lWqNvJntBrw==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2025-05-14T22:26:25Z"
     mac: ENC[AES256_GCM,data:LuB6AhpK7kkzDrwTdfkGQnOnA2be9Y72HkvFZzWYZEH2GQAZxlDFGRhgcZPIUiqQMFA9BYwz32sQ0ZJk19ypYC1UOyOe5ImVZwEjH8qEICwF+xIcCtJi3ohfC/oVnOKsoR/+j0Ar9/HQwaPK2sSQFRdebpgnwFtMSIGak0abUB4=,iv:RpFcCUT1VOCaE/BLIG/oc9b/wR8F0cwKKcSCo2EXa14=,tag:jXzEkA495Xvs06qnzcJwEA==,type:str]

--- a/secrets/hosts/oracle-cloud/free-x86.yaml
+++ b/secrets/hosts/oracle-cloud/free-x86.yaml
@@ -7,38 +7,38 @@ sops:
         - recipient: age1qwuz9ud98q82xpresskwkgd20r35u0valpddq973h2a9dad6cyjqxqmzt2
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyYlR4TWliNTFHWTR2S2lk
-            ZTE5MXZDck5sUmlhNmxrY0h6SnVzcktsSkNNCitFK1lRWjVHTUNYQ0lZN2hXdFhU
-            aCtMTlA2eGN0MVBMUjRuYkhBK05kV1EKLS0tIGlXOTdKalB1b0ZKb2FCUGFCVStY
-            czhSanljWkphQWRwMFdmaFRwSG1QWGMKlG0t/YSc2C6Z7U82GR+GKzMrQ7KnT8sN
-            lDxBqb6/0WGl/uEQEIzTPghRuafALrW5T1YuIWUu+fI6XcqDnZcN7Q==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0U29NeCtzZ0tCaEh0ZjRW
+            dHhNYmtUa3lxZVlmOGUrSFZMNEtUYkVKT1NjCmFwdEhITjhsaHpTeHliaEhaUVRk
+            NkdNL1pkV0JBakF2b0dlSEVyNExvdm8KLS0tIGlvTkkxbUd0N1BNemZIRnRtdFEr
+            UkxaL1NkTS9OTmdkN2xORHhFa0w2L1EKpLCMDtut8lMdbn/wVQw+jC3gH9+SWcAI
+            iukRnD3DjqkanHOCoC/vqHclvfVc74Z7Qtp41fme1IxccPObBSC3Og==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age17fq29yexw9rf30je5xp86hdda6tgug52sax7vy0af2sngempqv0qwhe4vr
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzQUM1aGViTlphQjZXSDZP
-            KzFqSmhJWWU3RDh2K2xkUXQvY2E1Rjk5TnhvCnM1YlNydXZzRUlJZkdDajMzUi9u
-            dWZHaHg1TllKb3BPTXIxa2RVMnJHL0EKLS0tIHpWWGl0WklTbFc5T1h0SnZ6Mldw
-            MEd5V3dKSXBoZ2ZDeDFVVzZhOGYyZ0UKy6dbOQ3izPCDhKTC0l3hCZuPIkLR9ZjT
-            MGz1fc5cH3CQoPcdZbJJx0XoDcSxJrO5euAstfg++3zo2ZhPvqeZOQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjV051UTZaVko0OFNid3Za
+            NHhJaXFPbjgyWjNWakJhVmJuLzZST0xRYlZBCjJGaDNpbkQvMGhXMytWTklUMlpy
+            dmtyZ2RXaERGRDlwaUdtcHRrdlAwNFEKLS0tIHJ2TE15cmpKVGhHNDYzZzVzWDFR
+            dStIV3RhQ0pBQ3BYMDRPWnJNbkRWaGMK4tAeC4MtbQfXS8ZGSKTOE7CTARE1RN5O
+            FhrUa/f2nXkLX6i7j63asTywiWjvJaQ1Ka1n3gb04IsoyTDQG4VEhQ==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1tpupgevxd2d50zv95c098c3xkfqed4zk46h8fag9stadj75dvu0q3wx0mk
+        - recipient: age1wcuzeqxgdmv6ev0ufawnu699pyxrqq565tae79sa2jfgnffvlvmq5xd03h
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIWHJYNXM5aExFdHRvcEl1
-            M3VNVUZTM2o2YnhNOU1lTnNOUC9JZDhoWlNRCjQ5ZkRXaEM5bHRGQ0paK0RTVUVr
-            YU9aUmNtYkhEQVNBbnF4eFFxZm1PWXcKLS0tIEozWFhFa2lXMHYvVWo4NWJZQU0w
-            QW9EZUlWc0xKeUV5cUJlc2pvbHZSa00KZMATivQpqCr2znZzb/kHet5+z5t3gl0U
-            XncXSTg/pW4Mv0cy4MWTkCmi8dA/s2/ggpDODU/dIvbrAzROgkkf3w==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrdnJRMEZpK29PS3JtL2Ir
+            QjdtWnFMQ1Z0WjJ0dVQwUFVLKzJzbWplMDFrCjZkMGVsbHBuc0ROYWFPY0Q2U3ZD
+            OHNCMmUzblRjNStsTnY5YnpzNXVWSTgKLS0tIDdrWWVCNGR3UHlpaVF2cUhrUHVD
+            TnpzdFNIN1BLR1kvaVV0d3JpVGhXK3MKcCs2OfcLbuxwHdY/5cEouYUwl+rCTk+O
+            lpvzZTwsvHfyyxMwIvczaL7KQJIh/kOcZINJy219XFdsHyBZm9ncQQ==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1wj8d6dpv8xt5m2kpusxzfkfuedp5j4qjszrtg0tnzevgkd3sla8q0wms67
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxVVdPYVpBbUJjOXNBMjh2
-            cCtOMjg3czF6VVFqY1cyM3dleExyZFAvRlRJCkphYXB0UmhOaUtYN3NhRFRSWDc1
-            ZlZVSngzTTVEMy9kcnBocWF1VTBRYzgKLS0tIFJrbFR2cFJEQTR1UGFuRUtVbHF2
-            cFBxQ2pkTnkrbm5LNmtmNmdYTWp4czQKJzkNB9PNuCagZMd7mJ+7F7bYegvcqeMK
-            pcULb043R2tQDVKOXZytP3Q0TTP3tE58wVO5eMrXxHL5GwC96UQo+A==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0UHR4U29IeThya1UxQ0lK
+            N3F6RmRPUVdjOU5SVkNoY0x4UWpRODB2TW1zCmJPYUhDNytlSCtLL2lGUmJrWDIx
+            NGtkRnFndDkrK0UrLzc0c1c3M0c1eXcKLS0tIG1XOTgzZzZtWmE3eFpBT1NtYy9h
+            KzdrcFRIU3hhUE1HWk9vQ3RiM0dPZ1kKxvcR7F+OKVvp3w4fmrB0s7b2Pn0mPEtq
+            UJ3FlRdckwD2ARDwZFIJiDHv6TXqTgdQODY+sqhoQdxFCpo/rFuJwA==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2025-08-26T21:20:33Z"
     mac: ENC[AES256_GCM,data:/UxCGJ2Dto86KGMLSOAaTR1MNO1Vmdr2AEO+mkHjqAsjOEo4uuQGaz9SrkcEjDDiHny6hjlqVYw2joshYb85uCBoi4tODMUewp7FBxFInIJNdPE4mfdV7NpCWwPp7U5ONslq1W9f8454SmcCoAZXGR058K2lphd9nenlLJqrr6U=,iv:V2A7L4oFnpNB8jx82qSv+1r8c6D5GgMz18bse7f5OHI=,tag:1ocRUa4OmhU946glm43RHg==,type:str]

--- a/secrets/hosts/pilatus/pc24.yaml
+++ b/secrets/hosts/pilatus/pc24.yaml
@@ -4,38 +4,38 @@ sops:
         - recipient: age17fq29yexw9rf30je5xp86hdda6tgug52sax7vy0af2sngempqv0qwhe4vr
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXS2R4UkZwWUxLL0wzYVdz
-            RVFtZGVlSTBNcndSWWNoNmt2QzhWbnVOUzMwCll2Y0p2ajVYNzgrWExIYXVCa0dv
-            TzM0Wm54V2tpb3ZncWgzM0pQUisycGMKLS0tIHkxdHNzeGxUSkdDOHhwZkRsK2Vi
-            L3RaeVpqTC9ZQldhTHRORUcyZWg0b00KiI9uSGIS+AdD1shUj9UN3NffaWL/YOyb
-            1HWQvvHEBe7lwibTL+O4f9Rr3hM9l4XI2094B/uvqkbEV0rdzz9RFA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxcmtneTE4akpyOW9TY29F
+            NFJQU0NuaTRGV3VQSENadmltOERRckZVWENRCjBSekJzTkd4Q1dWR2NIcjNLUEsz
+            SVNVUjhEbEFiekQxc01HWUswVHhacEkKLS0tIGZIK1YydFpra3IvTUtZalJWVHB1
+            REo0TEhwRGJRZzY5dGVwWHp1VXdlV0UKwfq507zKvHMRBM4SJZj3EGRQwqFKRC4u
+            feYQCmQZ9nbnVU6Bpm5yDdk3leSc80ezPDHUy7A5TpCBxe7axitovg==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1tpupgevxd2d50zv95c098c3xkfqed4zk46h8fag9stadj75dvu0q3wx0mk
+        - recipient: age1wcuzeqxgdmv6ev0ufawnu699pyxrqq565tae79sa2jfgnffvlvmq5xd03h
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUR0JudUpuMk55RnBPcmhL
-            N0ZDbVhLWHhJLzU4ZVVQaytIN2I3dlJSSlZRCndUS3F3MndlMEgyN1JYQVlmazdD
-            WE53NkIzMzBWWUVJVzRQRkFWek5nUHcKLS0tIERvVVpHTURWRU9maTVxTjhCK3lS
-            T2crNlZreE1ER1NjejZpWjF0czhadlEKkScCjPB1BRWYrmR9vKWXuQ3Tz99J+69n
-            qaAIl1fz7/x+fmLBPQ9HJQ6//tB+lj6KL1DUIx/kqua4Qc/NyQLuyg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnQjMzVmczbjBqejIzdVIy
+            cko4RnZkcHUvd05aRjU3dWpmRG9vZkQxelQwClZET0NML0VPWThVZUhkREl0SWRj
+            TStGWXVHY1ZGSVRINlhQT0pyQW11OU0KLS0tIFoxTURsbDNSUkFLMFVCbWpIZmlK
+            WldRT3ZkdmtWdE92Q2srVnRBYkVoMmMK9zNg1UHIKfRRzhjKbrzJ/hgc4qQ8EDOP
+            K00173PkyZPcpYDMGmvFyH/7tRx2l0j1TOHOiiPqsbYWVEbOWJYmQA==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1y2g734aqge4lsvmf8dw6s5rc8rkd0scmfwvxm3nlat6tu7y60a2s94yn0l
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUb3BsYzUxRUI5a1NHQXo5
-            VzdLYW00U3J0ZFN1Yk4rWnZrK21pZVhYZ3kwClptWjhKNUJ4SGRFRGpVSGErQmlt
-            d3lWTHZ0N2IxQ2hRcHI3VVE2RVhUMm8KLS0tIHB5bUtaNno3UExmZjRKZlpPaHlW
-            ZjdJQTV5bklCcU1HemVzazJPVW1lTWMK64fwezgUIXRDQEZRS2ar9Vv/I7DOfs4p
-            jk0KhMu55EtEJNzH0ufoTO1QwA7Z3fJDxFTjGXOQTikt/kjghJ3O2A==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6Q0lHTnlPNkg2SmtMZE02
+            d3MrWDZvNjhBbGhRRExlRGpaQjR1bjdLNUhrCndwbExOaGpvWityTk9BWDI0NVQ3
+            MkFhZ3JIUTJaMzVXTFpvNWFDK1h1L3cKLS0tIC9CS3NvQVBNY25rb2h2WHhLSXhK
+            ekIxUG1IdG9sMHcveFdzZ3BWekR4cU0KSbNAXDlvTt7iiN5k+IdjNmrQ2T1hhgM8
+            OH/8IsuL3YegDZRsobTVnsdPIlhnFqAycx9DAo6inX9bA2esDes4uA==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1wj8d6dpv8xt5m2kpusxzfkfuedp5j4qjszrtg0tnzevgkd3sla8q0wms67
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmZ0V1V2toVUF3cWoxWU1u
-            RjJ6Q0FzL0ZwRE4rMmx1OWRjOEJLRktGZjJzCnhEZzFhVXVVZlcvYVJrekdhRExM
-            TUFjWFl4c2kxUjE5WDFyYzNrZzNQMGcKLS0tIHVmSFN2b2laelVuZXRQMDZ1anBp
-            ci9QV0Y2U052bk9DNEtLaEpLQVhXM0UKJdgCTBK+piS20VW6DUYkLr3aK6SDypGY
-            re9jroPxhFoIxd4/g40hH7IC/lB6X90usl+nMTHxPdRjI4SW8KskyQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQQnhDbmkwQUlzQW5TSkhx
+            NHRFMUFNaXo0akpNaU9DVUY3YXZVREJzcldJClFRd2U3a1AwSUhTVS9LcGZpaDlu
+            UUhZWXA4UmJ6L252YUV1dTB6K09lVmsKLS0tIGdoZHJRbTdTQU9QajFPMk9NT0NB
+            TnJOTGJ1Ym1laXFzMzd3cWpmY3BnaGsKUdAe9anIsy2YmeyYA7RL1obbdSlijN2h
+            kiF7PgVBGbXBfQYI0C87E/ar8XckYgGWMlxqh2q3G6nFNAlIitCC9Q==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2025-05-21T21:33:29Z"
     mac: ENC[AES256_GCM,data:ADY3VW+mGQsRP9/g4y+V8jZwWVKq9sM9Wq8lGXnAQBXkiPlQuOn8/dBhVnoPX2P9XW+Tq+A8p6LVuZehjCxZApnmOajypsKXdrLvFA9OG7zWym5uOX6DBuEEDaIa9lMbhYdHmuf7KtabDVXeYfMhbVGt7+o0baoVFXRtgRu6qF8=,iv:eCFFQDwXKeLdYG3ItlyRpB+dHhklkWbj3CmuC/hgbng=,tag:jDgjPGpAIWmyQyaxkIb4TA==,type:str]

--- a/secrets/hosts/ucaia/zagato/k3s-secrets.yaml
+++ b/secrets/hosts/ucaia/zagato/k3s-secrets.yaml
@@ -4,83 +4,83 @@ sops:
         - recipient: age1w8kqhxusrglw4697ku3r0v6r0x42am4d6l8k6en96uvf7dxyrqeqwf3nsy
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzNHdOeGcvZzdienVWN05s
-            T0lkRjVnWC8ra1NqZmJzRlRlanI2UmdYVGhzCmlNWDlqSjRHQllPWm9iclJlcGhD
-            c1hPRlQxYTFHUXZ3OXAxZHpYQXk3OWcKLS0tIHFiOWo3RThhZUpPY1c0ejNMUERV
-            c2RNNXpiRUtwa1FwanA0V215SkI3WkkKjuNtCt89KMNJulQxeJbn95ZUJO87CDff
-            ZBRXdkEClQBmKthm046xGUsro0evBIC8uvv35mOXRnYgDnwNv06mNQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPeGxuM1J4Q21wS2FLVnVV
+            YlhvZENBNFM0ZWxpc3FickNuaHFtc2VhWnlFCjNiOGNWSFRVVUNjVzlGdTMxSy9M
+            Mkt0YU9Wa2gwYWQ3ZEpVbURvRzNpU1UKLS0tIGp5alFOV2tYYVJXU0ZpRVJ2VDlQ
+            Y05neEYvZ1B4TVEyVW1RTk9CNkZvUVUK/DTSaZuI1vdnMEI7Br5/19PBcPAbHJ91
+            5wTGARMDoZtCBygXOrDKQWR+6sAQPNB0QWxFnstqp1cn7o+sn462wA==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1uev6mgsfdkakk2kps2f6d05t9wckh5ex0dfxfwnfgyt20kyaxp6q0xzkd8
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBReEQ1R3Z1NnF3TUIyQ2NZ
-            MmhXK3l1UkZzVXhlTTJZQ0Q4aVhiODNrclFBCkplQ0FqRm9DQmFwMU0vSnJGQ1JX
-            VGVmeHYvbVV1NVV1SFluZzZqSzVwVjAKLS0tIDBSKzV2MlB1UG1XK1RmblhGUlN5
-            OVRmckI3aVFiMXZQdVJkUlJCQjZEcFUKxdtWYLaIl1gnlScEIqekhcYqNO6CSXoI
-            XyzO6lRltvFb/MJHy4D6Qihg3nnstGhvzFpLpKcKrWjm0uRWQnGwBA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoRE5jelYyRU5QbTRPNkVI
+            bTloSkpXUGd1dzNoKzR4dXgyUzhEb2lDNTBBCldTTnpUZ05mUlpvdW85aUNtc0g0
+            M0g3QU1OUXYzdVQvZldWaDBXU2NsUzAKLS0tIDBRaHVmZ2lONHc5UjVtTDBtNXR2
+            c2hBRmp2TjdoZWl4enNRQTNSZUE5U2cK5280MqL406Yq5AuJaWvmNMeXZ7US6xYK
+            Xiw9vZ8uc7gofSlk7GQ7SMCP8TOuch+LFNx0Jv6FQ3ZS+todx9tPkg==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1ddlymgwgj5p7438pltp6rfdpdwul54gsp0ue8az4jg22x82m7v9qgfev9n
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzald1cndnbk9MNjlvMmtL
-            SUZ0dDdZUmNaTzJWalpyRGNpUnZIbklqWlFjCmZpSytDd2YxcGIzbDd6a1VQeU5v
-            RmJzb3FjN3FWQW9hVng2Sk0vM0tHa2cKLS0tIHpSZkllZWRGTnhhekVDV1BDQnBL
-            eTAyYXFwa1Y1THRZeGg2OUF1UjNpVm8Kvzn9mEKLM8xKMOHZjyNYLTas3QCWjyil
-            VJ34N54sfjid62KDSTQ2nligKeYDzAHwjZRsn33Pjuc8lr78icXUHw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkWHpkV0syZWdyK3lsS3pY
+            ano2RDdKcU4wdS94M3JaRE0rWENPcFRoUmt3CkdkelhUMjhBaGdRMjJHOE9Jckpn
+            TTZadGpvWXk4aXk4MDNDSE5YZDlwWGsKLS0tIFF3d0RhMmtFUnlrTEdqd3BQWWg1
+            ZTNqL2tuVGFzTU1ZYnMyWnBoZWlrcFEKOaRLpl5TQ7jC4huVwcEobTnwNSry9WWR
+            Mdi3lvIHlF5zxsz05E3QhDG4klnUYg7H5g1Khy0qC+gV0WYPjIrywQ==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1htmygjfah9sxpnkky6nrcn3p5wj2d3ml5d06nux6djefcd2p854qtt8ta3
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBR003VzVyNnVtOERTaE1r
-            QkN2VTFGWktHb2o3MnJxVkdEWnBvVGV1TUNnCmFDcTN5ekhoOGJOdVJBaEFNREt5
-            dmdRdklUTmdCRG5KL2RRdzV1eWN6eHcKLS0tIG1BMkN3aU5JRHdja0NRNit1U3pS
-            Rk4xb3FSNm1BdTJtaUVnSkhFempjUFEKuW/DVo/sF2IXbxOE79orIf04PsMVhqLA
-            gxeGBwtfXp5JYXjX0viK01pUlXTDkbTHw7FqzL7Yh/AzQ8KJ2vIOyw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEendrZmlEZVZuZDFTQWZv
+            YTRtMmRLYjAwTzZ2NzYzWDU3NkpLUUNIblJZCm1CUVBaSzdmUEhlWUo2TElPQmtz
+            RHFpRW5xL2tGTlltQ3krMzRwMnVuSUEKLS0tIGVuSUp4T1djSmdwa3YxZ0pYK0FM
+            ZUh3VlNXVEtONjJac2l4ZXZUWEt2amcKugLqbn5AoOlh7vy6bYKMNsxuq76YnoNo
+            sryab1gJ2shwarAfMbVtxToBtESsMA+119mUcRvOrzkpmU0WrcL1wQ==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1s6af7sfp4elds8507wjtluuavju82kreqsjx9k8z6e84nwngtglqfracwg
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMOWF2amw1QnY3R1FmKytN
-            UG01NjZ6Z2xJcytQNkVNcXJHbjhUQ0R6UERvCnQzSjR0UlVBM2IyKzA2Nzd0Q2gy
-            cUtsS0tER3JVV2N0aHg3aE9rMWRmUFUKLS0tIDhzVno4ZUZhaGwwRnQ0dGtKemlo
-            WUlTY1ZQNjhQTDVZTEwyNngwWGxmZm8KsBnk7rCrIuvAcue6E3GECOFOs6bFlV1y
-            vO3wjNLCJ02j8L7h8tprtcNqsuda366CrYzbE9flKPp+BqtQ8rlgrQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLU3p0eEE3OVd0cUZTSE9t
+            L1B5Tzk5UmY4bURPR3o1Rlk2K1U2U1BTb2tBClU2ZUpCUVQwNUVzYkxmeExPZVg4
+            TE5oQWV1QUtOMUsvU3FDSXU1OXNsdDQKLS0tIC9ydy9nb2Y4NVhBS3Jlc1ArYWtv
+            bkJlZjhCOEdwd0FMTGJCZHByU1JRT1kKupCfnjbrAraOoBbzwBFYQkTGQmwSQ3Z8
+            WEHrKCNQ4u3VybD3rvoII/97QZAKIbpCMUB6uijwBDVM9XnoIsbHYA==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1jha9zrxs682wl53767u5gzm26terltfs2lcmd4djyj8t69t4se9qqrq83s
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSYm9wejdYeTl1UGtJL3hQ
-            dXN4VktXNkJzL212clJmUGJBSkd2VjhyNmpVCm9GK3pQQWIzcW9QUlBPOHJKdS9Z
-            YThvWFBLMENhZndyYTZZTFNWaFNyeDQKLS0tIFp4T2R0THQ1bXByQU9EWWJhNnlr
-            VGFHQmJFLzlCZ1cxYjZhTUN4RHIwNEUKAac+nEXcpGdGSEr46FpbDx0KQkQiT38L
-            Ld1yQTMbeK9R60Ntd3PD2xXzV+YTzlWn2fUQcLEblTTb1iyhaQhdww==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXNlJTODl4TGxQTE1UWGl1
+            MEU0L3AzbGx3enBKR2hUNjRNSWp6Ylc4cmdBCkZKYXBDYVpkZEREREtBVlZwdXFT
+            aXJURzFzNXFRS09TMmFDZ1FNMWdabFUKLS0tIDFnTlplZ1d6OW85YjZxUTRabWMv
+            MmV0Rm9Zc3hxQVB2U0k3T1pZdUtMKzgKDY847VpgWI4EYVChO5AxxN70HY/dy/Qb
+            SQsu1YRZ6CZgd0I8/nxs+Rd6XA/9ys0S5t0PgUnlucVnVkD1A3JIzg==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age17fq29yexw9rf30je5xp86hdda6tgug52sax7vy0af2sngempqv0qwhe4vr
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrZ01KbXR4bTZ6SFVWTmsz
-            TU5ET3RLVkFVdW1lZkNMUkU2VkZhSWY2aFFFCm5KN2JMdzZhVnk5U0ozRnk2MGhV
-            cU5oanJCY3VnbTVJZkxaVDd1am5zb2cKLS0tIEVFV0Zqd2NtRWJYZXdZMTI2T1pn
-            bVhJV0ozZ3N5U0FmT0JyRXFaYzJnYUEKhkr9SzWVxhGFb5OSJm2GU1ugMxhoQVn7
-            WIaNxycleYpWWHNFOx2HXVdIVjU5c+G2Pd7tFN5p7qC9JhMoTNnSqA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBONWl6ZmIwT0lnNmhobFpN
+            OG9YUGk0M0IvSk5LSmNGbkd0NCs2aXFhQWpjCmNwbHNENTFyZ1lHWVhBTUViQ2Vo
+            UnJWUkQwRDJIbXN0QkRwZEUyN1Y1ZkUKLS0tIGdQUVYwcUZrRHpLRFFPbXlDSnEv
+            bjNBaXhNZzdKeUZuaklEMU5UbUVVTTgKv6nynB2BFhdDhRzEL/YFJlz8SZRnZAt/
+            De/M2b2z2zPPpokdzurT/EW3TuAQ9eIfsSV07A6LWKVEZL6csJmlUQ==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1wcuzeqxgdmv6ev0ufawnu699pyxrqq565tae79sa2jfgnffvlvmq5xd03h
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmTjI5OG42dGZsRFJsUURj
-            Y1VsU3hJQUIzWUc4T1NEUE9xYUlHYjF4NFFnCmNlNDNLYU1sb253KzVOZkVFRjc1
-            Y0o3MjhhNzUyRWVJZ25NVllYS2xJUkUKLS0tIEJTWGRJSXJBTGx0dTJaQVBDeWpZ
-            d1RlSWY2empoK1EzTEFTV3ZXQzJJb00Kfk3aPfSYdNX8byV1VnnerM6a4/KlMJ0s
-            5vuOCrDYkoJ5kMOWZs5N9jXa8kCweQ+rMuu7P4OXlVZij61n9WBoyA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwS2d5cWFyN1ZxR0gyR1U0
+            VEI1aFpGdFl3RUZ1UmY4YVZFdGU5ZEkxMENvClhTUW00eEhWaU40NmoyUkdrTy93
+            WlBlNHl3cW9vV2RyZEZ0OWU2QnBZT1EKLS0tIGp2THhRMFZyOFhIVVg0T1EvRGtE
+            aGk3ZGRIOVl2NXlvQlRKUkxYd01MTE0KvbDTredL7+ueijBguPdq8dGm6hqzrVaK
+            2n9aI4VVr6Fi1iBOFFWkWbou7H+7NoRxmyAEYazTc38N5azw5eltqg==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1wj8d6dpv8xt5m2kpusxzfkfuedp5j4qjszrtg0tnzevgkd3sla8q0wms67
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGN0xCN2IrYUxEempZR1Js
-            WkRqR1BlLytydGZ4M3hMbUoyeDFCZ3BvZEFrClNWeVF3OGM0dk96MHh0M1VlK2FG
-            K2liWkxDZ1BaeE5ueXNsbjRGZFdrRUkKLS0tIDdmZmlGWEh3VnlJMkQrOXV3YkVt
-            UlpsdDJOd3YxcG1yNmpxZ1ZHTXE5ekUKC0VncUyAiGAcQYEhW07aGgaMnUHtd5/h
-            TsMewblSNM/R5A8X1/mkVmISB1Q2ZTJ9r6ijZh+J8xytUD/6mEmC6Q==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqUHVsdnIwckJIZ1VnZGFB
+            aWdFMzU3SGI5eHZ1ZXpZMlVnYUxHdk5xSmhnClRyN3c0Unh2NC9IZXNVNFoxTGNz
+            Sm82Vy9pQVVOZitjcVFIdVBYaDltdGcKLS0tIG14L2ptSC9PY2pUTEI2eFNLOVNh
+            NXVQNVZUOVpjNFNYTGZYSFFTeXJNUFEKsg92lSm/7pBeBgQYVKHKkxBVqD/tFNd7
+            W9yp/zk+TkVEVkvUiy8EQV0cijNYr59f4bI3493EQ8hBwiF3b22mQg==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2025-06-20T08:38:06Z"
     mac: ENC[AES256_GCM,data:GcS/KUGp5axi0ampLe2teeckOdwS/B5I5nnKua/fhhCbMGclBitb+DF/FKwui7lrq1hXd4yznCGy0hZMUrjGHDe9bDj2SnFwmNAFKzVITTyK0vpbyXUUCqEQdm91yaf+LDjYI4EqgXobpb0Pz5eXmAOgTJwPDu4doxOKDs0P4CI=,iv:6huAGYlqD0K8CR4RVoxQtPZsoNLqUPDrH/4zYW5ufMs=,tag:HXDMMxl1wiZXuVMkgeHlHA==,type:str]

--- a/secrets/hosts/ucaia/zagato/k3s-secrets.yaml
+++ b/secrets/hosts/ucaia/zagato/k3s-secrets.yaml
@@ -1,59 +1,59 @@
 k3s-cluster-token: ENC[AES256_GCM,data:PoWj4wKOrlR6ummTcGgU89JpruzuBdxIb7Z//ninN4g=,iv:qoCfSJtxyoOLiEX9VQZ9ouOqjiujZVgST3dsMR7vJks=,tag:UkiOmRgCTtvqJhFv9gkXFg==,type:str]
 sops:
     age:
-        - recipient: age1xeltrwejcsrx8l8usdwhw460gl9wc83etwsk0peszhyngv9gns8qcg55rq
+        - recipient: age1w8kqhxusrglw4697ku3r0v6r0x42am4d6l8k6en96uvf7dxyrqeqwf3nsy
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqZFVrS1VVSVgvL3hFN3hF
-            c0ZMdDl1bzdQWGxEMTVFeC9uaHhTNGRCTVdZCmFZdFFyaUhSbmtJUWdhWG1OaVlU
-            TDZSUEpPUE9JajdWN05uRlRHajNFK28KLS0tIGtoVWR1bHorWWUvQUFiODd4ZlRp
-            aDhxcnBySkZLejZ2elFMUFBzcFJKRWMKiXer6Prh/S5Ss15sf534vtM2agRYF/G3
-            Sg4h3UyDFc9iNTWfDUIExPaDZ2CuB6+s+qbuRdwxrvMBdSyIZk/FMQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYalp0Mzk5TXA2YWMvVFVu
+            aXlzMGhidDZtOWszdVJ0NHFxVGE4NU9RcHlrCm8zcG9KaCtMT1hKNllHazBXVHJk
+            TXhiUjdNRENGd2FFSHJRc2Z4K2RCemcKLS0tIFhCRnpJMEVQb2xlcHB4RzR1bVpN
+            TFBMZUVtdjRDVWFvZ0JtQm1ocTFuWlkK3z1ZUwN2ekhDJ6KWftAnaISjosgHV+Ac
+            21owKwf7AFTTNwKdu1FdP/oWSleBYPzKwE5tXrJdzUxk/y/OdKxAaw==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1lm2j0n3e52ve6pdeqjxkuuxs4wgtm0tv2t92x8c5ayjwm0lwxv6qsruxdq
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXSm42VTFjbnZDbitnS09Q
-            dDVMbm5Ycyt4UUE3QkYwZlpMd0VUYm5va3dFCk5kZDdGVit4YTljRDdXNDRXNVcz
-            em9WcHJkN0EyZWk3bEpaQzM2U2F4SVEKLS0tIG1XWXhpbjIvT25qL3hlWlNUazNF
-            QXJBZk1sc1V0eGJjeTlNK3NoUWVyVGMKKj6pLq3y5vATk/XuC2LpDcG05S/IJy0y
-            JplCDEUrSMBFZLtQ+OEIxaLiGj7QqxML5qJVgTHJMS9CATXBjFX87w==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNVEN1M0NRZ1Y1QUQwRVhw
+            bHJmRUx5bC9xbGFIR3JEc0pIeHd1UnFPdmxnCnVHVjhETFQ5di9NMWlSaWlERGhy
+            b2t2bDFTa1MzS0FGeFIxaVBYR245NkkKLS0tIGFyKzVxenpieGRnVVNQRXJUSnBF
+            VGgreG15SHZjZ0hsMmxXNU04ZlVvTWsKk9aObDWquN32/1D45yZ05kcWAl5LqOP1
+            nTVOQBsQMsu74vD8LIxDyrc8FcJeqDaS7pbvResA2ylanI/XSUB8mg==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1nkz255qkgpwy4myetz9dyl5hdh2cpenv52fgpya5gwdc5e9prqhq7ns4lq
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhblhSS3Z4aTJIa01pNjNW
-            R3c1TGJvR2tKaWZCNklFOGtTZE5zUnlvWVhZCkxLTzFpVUgyR3NCQmtQQ2lMcW9M
-            djNJdlAwZ01zN2c1QVozYVVjQXAwWmMKLS0tIEs5LzVvQmZ6KzdYbTZ1Z3ZqMENu
-            cTF1clc3TGF5VmYxdGVBcDRDeG5XQkkKcG4qtgjzfs1NkAaBpEDdbeXIAGQYWxIv
-            69lrymY4ZuBe0LWU4disPiip97CbaoLr6lA5KTzKxvFgVMpdauyiCg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRa0V1d2J4Mk02R3VoV1dL
+            Z0VsdG5pODNFSnlJTXoxcXo0eVg2NlJBODBjCmVXbEVjTlB3QytvTHlqNEsxRGc0
+            aHliKy9KV2c5MWFlVS9yY09CQlRqUVkKLS0tIDZSVFB3NlY0YmNnRytrc1pjbk1I
+            MzBSVnQ3bnZ1Z25TZ2lGUEpMUEVTSDQKpBclIFmw8XJKlBSWM3HsOVu1e/gNDzH7
+            v2vQhM1uttFZCNGs/VfgUAKDxmdJ75QjTKRns5gPqFzRyIUww/whPw==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age17fq29yexw9rf30je5xp86hdda6tgug52sax7vy0af2sngempqv0qwhe4vr
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAya25aOTA2czR3b0R4MDRz
-            MFZzNXlLQ0x6NUpEeDVOZC9LajUyTWJQK1VjCkNGL2hFTXBtbFRKaHAzaEVXQS9w
-            TDZ0SWdkTE5lb2FwQnRsRFdPVkdwTlkKLS0tIGFWYVZJQnFXKzRQQjRsMktXOU02
-            MXhmWVZDRzFEZEkxQkVVYXByZjB2VlEKxVE/uD1/5r2ceEzTLH06zUuGR9zgrpQS
-            1/jyokvgLOAOnLMxnaFujQjIKjgm5sjxIIsNlrCdkP52vBV1XJwixA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByb2VJazNrc1dNdjdtZmcv
+            ZERSQVU2NCtnTDgwdGZSUGM0NGN0NzNOU1Q4Ck0wdHFQYzFYQkxrRXpTVjgxVHQ3
+            Y1JLQ0JIc2dqd1U3SXp3UVkxZ0JrRnMKLS0tIHZEUklYWXI5MU5VZEw2WDdrRWlU
+            M3JKbTgxOXZ3MHBZNmVpK2grQTJTVGcKTBoJ8TVkdATZf44CU7wEO5JLBGDvvDDJ
+            UB+1Jaru4PTNqyj2a8UyooBmCxXs8KK/JGcdGwzQ2V9y2lmtfsym/A==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1tpupgevxd2d50zv95c098c3xkfqed4zk46h8fag9stadj75dvu0q3wx0mk
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpaGt2LzFJTjAraXpZbjZT
-            dkJXV1lwUjd3cVJnOS9TcDZ0ZER6L1l5QTBBCmFKZDhXSkl4TE9PNlBSR3hURk5s
-            aUdIY1l0ZktZdmZGOTJlQ3NXU2xWSVEKLS0tIHZSdDM4VE1UMmxlV3dmTEpWVktq
-            ejkxbkNoV1plMzJCUkxaRjVzUnk4TUEKsCRTy9uXjowCqu2Jp9+0K/IqyY94TUOd
-            R3ChBypfkUV8Gjqwt5T2+/zfVJ+5pW29DHm9OR07Xzo8HBIBF/rGIw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5Yzk1U2N3K2ZydVZrNlNt
+            d08zL3p5eXBMa1FnalB0Q1luc3pVMUt4OGpzClVTUnBiMGRjT2UrT3VPajBncDND
+            WWRQajFPNXpZTEo3RVM5VGxscHc2ZWsKLS0tIDBLZmt6M2tCaXQ5Z0tlYzVyUUhW
+            MGVHYVJqcVBLY0MyUmFBL0VUUEFXWWcKw3MOZkskipWVaokHgNxpLN36dPDD/WyU
+            8OaDq/KOJv67RpQe5v/ADnfIQZoMk1ztRMuruJxpyk+pw0cUetEMUQ==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1wj8d6dpv8xt5m2kpusxzfkfuedp5j4qjszrtg0tnzevgkd3sla8q0wms67
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDUWV4V21LeHl4ZEJaNW96
-            L2pySmhQbFNZbUZCQjRFUkJaNitrV2NDb0ZrCjgwMW5pY2JuQ1NtTGdzdGZKOXVi
-            enh2U0Ixd0w1aER2WXdSS1Vycy9yS2MKLS0tIEJ3UjM1QlpoMDloOWFhak83STE0
-            UXRZN2NzTDNobis5Mk5OSFVWQXZzdEUKnEhX4WLNZv46A6s0H+RF++/KAkSRgAwA
-            pSTEMr+OszPKRnXjfvWg1dpNdbyFPYmtKfTtrrIZCSOLF7oksn58Ww==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIek00MzFndDRZOU5iRjVr
+            S3llVFhpNEYycGlPekR4OHYzUEg3b1BmTHlFCk1aY294Wm4yWE94d241eERuMXgw
+            NlhIaFdobWJzc3ZucGpESmxEdWpwZ0EKLS0tIFBNNkVQR0kwdk1tcWx5Q2J2bzJy
+            bTdKSVpWcmZUMy9sYUxzSWJFT282N1UKI/qiSeHFfDN73gGo/usUyP5wPA7qdz4c
+            /HTzRJ9ciq1+ztZOPhJve26VEqnSHRh9XNLg5rCYdOTMFjSrM3W0xg==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2025-06-20T08:38:06Z"
     mac: ENC[AES256_GCM,data:GcS/KUGp5axi0ampLe2teeckOdwS/B5I5nnKua/fhhCbMGclBitb+DF/FKwui7lrq1hXd4yznCGy0hZMUrjGHDe9bDj2SnFwmNAFKzVITTyK0vpbyXUUCqEQdm91yaf+LDjYI4EqgXobpb0Pz5eXmAOgTJwPDu4doxOKDs0P4CI=,iv:6huAGYlqD0K8CR4RVoxQtPZsoNLqUPDrH/4zYW5ufMs=,tag:HXDMMxl1wiZXuVMkgeHlHA==,type:str]

--- a/secrets/hosts/ucaia/zagato/k3s-secrets.yaml
+++ b/secrets/hosts/ucaia/zagato/k3s-secrets.yaml
@@ -4,56 +4,83 @@ sops:
         - recipient: age1w8kqhxusrglw4697ku3r0v6r0x42am4d6l8k6en96uvf7dxyrqeqwf3nsy
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYalp0Mzk5TXA2YWMvVFVu
-            aXlzMGhidDZtOWszdVJ0NHFxVGE4NU9RcHlrCm8zcG9KaCtMT1hKNllHazBXVHJk
-            TXhiUjdNRENGd2FFSHJRc2Z4K2RCemcKLS0tIFhCRnpJMEVQb2xlcHB4RzR1bVpN
-            TFBMZUVtdjRDVWFvZ0JtQm1ocTFuWlkK3z1ZUwN2ekhDJ6KWftAnaISjosgHV+Ac
-            21owKwf7AFTTNwKdu1FdP/oWSleBYPzKwE5tXrJdzUxk/y/OdKxAaw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBreE9Sb2lDL1ZoL3hyNkN5
+            V3dHTTIvaThGSnFxUml2eHQxZGZVMzl6R3hnCnRtUG5xNWYyN2xIaSs1ZFVzckt6
+            Z1d4cjAyL3I0TEtKbGVQTzFiYXJZb0EKLS0tIEtqczgwNlIwenVuNWxuTFhlZTNp
+            N0lpYWwzK05vWVluZ3VyYkdTUVczL28K82T4BnL6VKFtQg0HDkxqhLVejlubj7hg
+            iFRKoPym+Pgu0AGDMvaHtMLx5ZGYHK7/YOi5Y+ljExwf2wB7NwSK3w==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1lm2j0n3e52ve6pdeqjxkuuxs4wgtm0tv2t92x8c5ayjwm0lwxv6qsruxdq
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNVEN1M0NRZ1Y1QUQwRVhw
-            bHJmRUx5bC9xbGFIR3JEc0pIeHd1UnFPdmxnCnVHVjhETFQ5di9NMWlSaWlERGhy
-            b2t2bDFTa1MzS0FGeFIxaVBYR245NkkKLS0tIGFyKzVxenpieGRnVVNQRXJUSnBF
-            VGgreG15SHZjZ0hsMmxXNU04ZlVvTWsKk9aObDWquN32/1D45yZ05kcWAl5LqOP1
-            nTVOQBsQMsu74vD8LIxDyrc8FcJeqDaS7pbvResA2ylanI/XSUB8mg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKVUZkOGFheVMxSmMxMHFk
+            byszK3IvWTZPU1I4cVdsc3pkN0JWRWRyalhrCllNRk5WU1g2TnRYUU4yc0d0RHRH
+            REtnUUJwRFNyYUZubXZiRCtnN2dyN1UKLS0tIGdQWThSU244bGNlSVNiRG5jMnVs
+            UFd5R1plaXdxNThKRmJOQ3ptWVBLdnMKWf86cO+reVxd1iwvmCJ1pT0Zi2VyqiDH
+            o5W2B9oyLKyuJh9BdJ7GCkrSFmDuQBNsqOtU46EsGdy+d6ySXQSDQA==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1nkz255qkgpwy4myetz9dyl5hdh2cpenv52fgpya5gwdc5e9prqhq7ns4lq
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRa0V1d2J4Mk02R3VoV1dL
-            Z0VsdG5pODNFSnlJTXoxcXo0eVg2NlJBODBjCmVXbEVjTlB3QytvTHlqNEsxRGc0
-            aHliKy9KV2c5MWFlVS9yY09CQlRqUVkKLS0tIDZSVFB3NlY0YmNnRytrc1pjbk1I
-            MzBSVnQ3bnZ1Z25TZ2lGUEpMUEVTSDQKpBclIFmw8XJKlBSWM3HsOVu1e/gNDzH7
-            v2vQhM1uttFZCNGs/VfgUAKDxmdJ75QjTKRns5gPqFzRyIUww/whPw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNYTJTTEFtU3VVUUtGMVBJ
+            Q1Fjcm4weStZOVNZNk90M1EwS3U5ejE5R0Q4CmRSb3JzNEk3cnpEdnJSditJcW1y
+            SkszWmFqSTRXUHdyZXM2bzJLS0h6UnMKLS0tIExMTHU3OFc3NVBWVzkxSWoxSVRk
+            SGU0UjFMVmtlQnVQSVJMeEh2TWIzdTgKCE4AXYMTi/EantJRS+im1XR78S6fnPfF
+            wJ3hq9T2o2oSJeYh5jFFO8B8Oshfu1U+vwvLpnTWqx1XG1kVAX80QQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1htmygjfah9sxpnkky6nrcn3p5wj2d3ml5d06nux6djefcd2p854qtt8ta3
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVZTBoZGQrbHhmWUNNUnhZ
+            RUlJOGR0R2JuTC9oZGZEUDNvYzdWekFKc1U0CmJGMkgyUW1nZzJSZ0hXazNrcVEw
+            cHJmVXdwQTI2aG5aMDBoUmprTEFBMTgKLS0tIHFKSWhteUt4NUVzeERyakdMdno5
+            bVBNUGE3cFBhSWNueC9zY3VsT3ZlWTgKU1iltZbeEci9X+LmTEPe9rrOVAl3X8HK
+            pMw0R6/c2QstbHF9oB5/rG5qJLtYXKIuHCgEO7n8UAWVorOXYDwI+g==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1s6af7sfp4elds8507wjtluuavju82kreqsjx9k8z6e84nwngtglqfracwg
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrS2VzaHVGV0Z5dGkyUXY2
+            bzY1TlVqMHBuMTFsVjNrbEd3SU5GNlh5MVVzClVMRm9EdUhRc3lUbGtVVHpITG93
+            OTR0SDVTMzdsQkdZUC9OZ3FCN3RzdEkKLS0tIEI0aGlqZ1RiWGQraUpLOUVZQlhx
+            NDhScEFiQ2ZiR3Y2RlY1dkYzZndNemMKJHmwUZg+Z68GICaxfj51eUYWyXd11BKZ
+            yP/RQkS5lyK9T8hNPrKGeYrVfB3RNmGLafx+Qdl3mxk5GGQDO7SiTw==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1jha9zrxs682wl53767u5gzm26terltfs2lcmd4djyj8t69t4se9qqrq83s
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRdU1RVUhiR2F0K25lRG5G
+            eGtSK1hGaFN3ekFrVjh3Q1UzN2tEUlFXVUhJCmJtRS93SU9WcDJPb2xzTnUwK2lQ
+            eXFwVVBuaXFpRmVTWjFiQkxJTGNpbXMKLS0tIEtVUnpmTDJGS0dpTVIxYmhCaEV3
+            VXg2aCthYjhxSmFUTkNJbEVqcTJuaWsK+6U7loNZu6yUOOAW7zbELxugLCsgIU+u
+            3qHpVBOgN0jNpMVu14ha0+u4sX/7Po9sLXsDO2zvzgWdmerkZqWq5A==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age17fq29yexw9rf30je5xp86hdda6tgug52sax7vy0af2sngempqv0qwhe4vr
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByb2VJazNrc1dNdjdtZmcv
-            ZERSQVU2NCtnTDgwdGZSUGM0NGN0NzNOU1Q4Ck0wdHFQYzFYQkxrRXpTVjgxVHQ3
-            Y1JLQ0JIc2dqd1U3SXp3UVkxZ0JrRnMKLS0tIHZEUklYWXI5MU5VZEw2WDdrRWlU
-            M3JKbTgxOXZ3MHBZNmVpK2grQTJTVGcKTBoJ8TVkdATZf44CU7wEO5JLBGDvvDDJ
-            UB+1Jaru4PTNqyj2a8UyooBmCxXs8KK/JGcdGwzQ2V9y2lmtfsym/A==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHSU1lNWh5eGgveUJtVmls
+            ZkV4V1B0eC9MaGRLeER6MmZuOHplNjNtWnlRCjVWOTNTdmxNRkYvV3ZBNXZsL1hU
+            T0dXMnlrVmhObFIrYnpOR3Q2aENWVU0KLS0tIDhJczNDajJuREFHK3pDVnNBc3dU
+            R1BUTk5nQmtlLzVyNEthejNHY1Zmcm8KwT8XN4rcAkagwdJRAyyV5lYwzrUWAucZ
+            H5zn7Qse+ecjyTt9W3NDKISp6/Fp92ArAoiQYwxevxBB3y9mKTGhsA==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1tpupgevxd2d50zv95c098c3xkfqed4zk46h8fag9stadj75dvu0q3wx0mk
+        - recipient: age1wcuzeqxgdmv6ev0ufawnu699pyxrqq565tae79sa2jfgnffvlvmq5xd03h
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5Yzk1U2N3K2ZydVZrNlNt
-            d08zL3p5eXBMa1FnalB0Q1luc3pVMUt4OGpzClVTUnBiMGRjT2UrT3VPajBncDND
-            WWRQajFPNXpZTEo3RVM5VGxscHc2ZWsKLS0tIDBLZmt6M2tCaXQ5Z0tlYzVyUUhW
-            MGVHYVJqcVBLY0MyUmFBL0VUUEFXWWcKw3MOZkskipWVaokHgNxpLN36dPDD/WyU
-            8OaDq/KOJv67RpQe5v/ADnfIQZoMk1ztRMuruJxpyk+pw0cUetEMUQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBY3RyajZsQlpBK2pubFBy
+            dTRmdG9BV3FBelZ0RWxUdGhVSkZxNjNtNzNjClVKL3BPRUZIcmU5RXNvY0Z0bWVF
+            Um5vNFcxblVvR1U4dHZkamdYVGNxZ2sKLS0tIDBFSjh0RVhTYWl5ZC8ra3c1M3Nq
+            eittTlkvOHNUOGhOd29vek9aOFFsdUkKEeuLNo84lQojwDPEwViEWOqBvfJfay4n
+            yITpK5C7YXvNkVyz5G4AQHqIZCeHal2XCj6O1zPCFZ1h55kdThGhpA==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1wj8d6dpv8xt5m2kpusxzfkfuedp5j4qjszrtg0tnzevgkd3sla8q0wms67
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIek00MzFndDRZOU5iRjVr
-            S3llVFhpNEYycGlPekR4OHYzUEg3b1BmTHlFCk1aY294Wm4yWE94d241eERuMXgw
-            NlhIaFdobWJzc3ZucGpESmxEdWpwZ0EKLS0tIFBNNkVQR0kwdk1tcWx5Q2J2bzJy
-            bTdKSVpWcmZUMy9sYUxzSWJFT282N1UKI/qiSeHFfDN73gGo/usUyP5wPA7qdz4c
-            /HTzRJ9ciq1+ztZOPhJve26VEqnSHRh9XNLg5rCYdOTMFjSrM3W0xg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxZnlxUDl0d3pGMUF0L3BY
+            OGNvcm5EbmR0VVBjU1R5QjBwbjZvMkpZMGxVCjlJdC9weklSSndodTJKZTdIbDRN
+            Tk1Nc3VvV3NrSFl5akVPY2hNazV3bFkKLS0tIFR4QmgyNjBISG55bXJDQlNON2h4
+            aXpYL3VKNFprRi9xd09CQkFjS2FVL2cKP6QpBWu2xdSstqb4vmcJ+uN98+IgB7zk
+            j4pYX+Bv8qp3XFHnvJK+f7oZm1V/EJ7HzTYInydEcq3IvXAyUT+1Ew==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2025-06-20T08:38:06Z"
     mac: ENC[AES256_GCM,data:GcS/KUGp5axi0ampLe2teeckOdwS/B5I5nnKua/fhhCbMGclBitb+DF/FKwui7lrq1hXd4yznCGy0hZMUrjGHDe9bDj2SnFwmNAFKzVITTyK0vpbyXUUCqEQdm91yaf+LDjYI4EqgXobpb0Pz5eXmAOgTJwPDu4doxOKDs0P4CI=,iv:6huAGYlqD0K8CR4RVoxQtPZsoNLqUPDrH/4zYW5ufMs=,tag:HXDMMxl1wiZXuVMkgeHlHA==,type:str]

--- a/secrets/hosts/ucaia/zagato/k3s-secrets.yaml
+++ b/secrets/hosts/ucaia/zagato/k3s-secrets.yaml
@@ -4,83 +4,83 @@ sops:
         - recipient: age1w8kqhxusrglw4697ku3r0v6r0x42am4d6l8k6en96uvf7dxyrqeqwf3nsy
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBreE9Sb2lDL1ZoL3hyNkN5
-            V3dHTTIvaThGSnFxUml2eHQxZGZVMzl6R3hnCnRtUG5xNWYyN2xIaSs1ZFVzckt6
-            Z1d4cjAyL3I0TEtKbGVQTzFiYXJZb0EKLS0tIEtqczgwNlIwenVuNWxuTFhlZTNp
-            N0lpYWwzK05vWVluZ3VyYkdTUVczL28K82T4BnL6VKFtQg0HDkxqhLVejlubj7hg
-            iFRKoPym+Pgu0AGDMvaHtMLx5ZGYHK7/YOi5Y+ljExwf2wB7NwSK3w==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzNHdOeGcvZzdienVWN05s
+            T0lkRjVnWC8ra1NqZmJzRlRlanI2UmdYVGhzCmlNWDlqSjRHQllPWm9iclJlcGhD
+            c1hPRlQxYTFHUXZ3OXAxZHpYQXk3OWcKLS0tIHFiOWo3RThhZUpPY1c0ejNMUERV
+            c2RNNXpiRUtwa1FwanA0V215SkI3WkkKjuNtCt89KMNJulQxeJbn95ZUJO87CDff
+            ZBRXdkEClQBmKthm046xGUsro0evBIC8uvv35mOXRnYgDnwNv06mNQ==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1lm2j0n3e52ve6pdeqjxkuuxs4wgtm0tv2t92x8c5ayjwm0lwxv6qsruxdq
+        - recipient: age1uev6mgsfdkakk2kps2f6d05t9wckh5ex0dfxfwnfgyt20kyaxp6q0xzkd8
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKVUZkOGFheVMxSmMxMHFk
-            byszK3IvWTZPU1I4cVdsc3pkN0JWRWRyalhrCllNRk5WU1g2TnRYUU4yc0d0RHRH
-            REtnUUJwRFNyYUZubXZiRCtnN2dyN1UKLS0tIGdQWThSU244bGNlSVNiRG5jMnVs
-            UFd5R1plaXdxNThKRmJOQ3ptWVBLdnMKWf86cO+reVxd1iwvmCJ1pT0Zi2VyqiDH
-            o5W2B9oyLKyuJh9BdJ7GCkrSFmDuQBNsqOtU46EsGdy+d6ySXQSDQA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBReEQ1R3Z1NnF3TUIyQ2NZ
+            MmhXK3l1UkZzVXhlTTJZQ0Q4aVhiODNrclFBCkplQ0FqRm9DQmFwMU0vSnJGQ1JX
+            VGVmeHYvbVV1NVV1SFluZzZqSzVwVjAKLS0tIDBSKzV2MlB1UG1XK1RmblhGUlN5
+            OVRmckI3aVFiMXZQdVJkUlJCQjZEcFUKxdtWYLaIl1gnlScEIqekhcYqNO6CSXoI
+            XyzO6lRltvFb/MJHy4D6Qihg3nnstGhvzFpLpKcKrWjm0uRWQnGwBA==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1nkz255qkgpwy4myetz9dyl5hdh2cpenv52fgpya5gwdc5e9prqhq7ns4lq
+        - recipient: age1ddlymgwgj5p7438pltp6rfdpdwul54gsp0ue8az4jg22x82m7v9qgfev9n
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNYTJTTEFtU3VVUUtGMVBJ
-            Q1Fjcm4weStZOVNZNk90M1EwS3U5ejE5R0Q4CmRSb3JzNEk3cnpEdnJSditJcW1y
-            SkszWmFqSTRXUHdyZXM2bzJLS0h6UnMKLS0tIExMTHU3OFc3NVBWVzkxSWoxSVRk
-            SGU0UjFMVmtlQnVQSVJMeEh2TWIzdTgKCE4AXYMTi/EantJRS+im1XR78S6fnPfF
-            wJ3hq9T2o2oSJeYh5jFFO8B8Oshfu1U+vwvLpnTWqx1XG1kVAX80QQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzald1cndnbk9MNjlvMmtL
+            SUZ0dDdZUmNaTzJWalpyRGNpUnZIbklqWlFjCmZpSytDd2YxcGIzbDd6a1VQeU5v
+            RmJzb3FjN3FWQW9hVng2Sk0vM0tHa2cKLS0tIHpSZkllZWRGTnhhekVDV1BDQnBL
+            eTAyYXFwa1Y1THRZeGg2OUF1UjNpVm8Kvzn9mEKLM8xKMOHZjyNYLTas3QCWjyil
+            VJ34N54sfjid62KDSTQ2nligKeYDzAHwjZRsn33Pjuc8lr78icXUHw==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1htmygjfah9sxpnkky6nrcn3p5wj2d3ml5d06nux6djefcd2p854qtt8ta3
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVZTBoZGQrbHhmWUNNUnhZ
-            RUlJOGR0R2JuTC9oZGZEUDNvYzdWekFKc1U0CmJGMkgyUW1nZzJSZ0hXazNrcVEw
-            cHJmVXdwQTI2aG5aMDBoUmprTEFBMTgKLS0tIHFKSWhteUt4NUVzeERyakdMdno5
-            bVBNUGE3cFBhSWNueC9zY3VsT3ZlWTgKU1iltZbeEci9X+LmTEPe9rrOVAl3X8HK
-            pMw0R6/c2QstbHF9oB5/rG5qJLtYXKIuHCgEO7n8UAWVorOXYDwI+g==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBR003VzVyNnVtOERTaE1r
+            QkN2VTFGWktHb2o3MnJxVkdEWnBvVGV1TUNnCmFDcTN5ekhoOGJOdVJBaEFNREt5
+            dmdRdklUTmdCRG5KL2RRdzV1eWN6eHcKLS0tIG1BMkN3aU5JRHdja0NRNit1U3pS
+            Rk4xb3FSNm1BdTJtaUVnSkhFempjUFEKuW/DVo/sF2IXbxOE79orIf04PsMVhqLA
+            gxeGBwtfXp5JYXjX0viK01pUlXTDkbTHw7FqzL7Yh/AzQ8KJ2vIOyw==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1s6af7sfp4elds8507wjtluuavju82kreqsjx9k8z6e84nwngtglqfracwg
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrS2VzaHVGV0Z5dGkyUXY2
-            bzY1TlVqMHBuMTFsVjNrbEd3SU5GNlh5MVVzClVMRm9EdUhRc3lUbGtVVHpITG93
-            OTR0SDVTMzdsQkdZUC9OZ3FCN3RzdEkKLS0tIEI0aGlqZ1RiWGQraUpLOUVZQlhx
-            NDhScEFiQ2ZiR3Y2RlY1dkYzZndNemMKJHmwUZg+Z68GICaxfj51eUYWyXd11BKZ
-            yP/RQkS5lyK9T8hNPrKGeYrVfB3RNmGLafx+Qdl3mxk5GGQDO7SiTw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMOWF2amw1QnY3R1FmKytN
+            UG01NjZ6Z2xJcytQNkVNcXJHbjhUQ0R6UERvCnQzSjR0UlVBM2IyKzA2Nzd0Q2gy
+            cUtsS0tER3JVV2N0aHg3aE9rMWRmUFUKLS0tIDhzVno4ZUZhaGwwRnQ0dGtKemlo
+            WUlTY1ZQNjhQTDVZTEwyNngwWGxmZm8KsBnk7rCrIuvAcue6E3GECOFOs6bFlV1y
+            vO3wjNLCJ02j8L7h8tprtcNqsuda366CrYzbE9flKPp+BqtQ8rlgrQ==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1jha9zrxs682wl53767u5gzm26terltfs2lcmd4djyj8t69t4se9qqrq83s
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRdU1RVUhiR2F0K25lRG5G
-            eGtSK1hGaFN3ekFrVjh3Q1UzN2tEUlFXVUhJCmJtRS93SU9WcDJPb2xzTnUwK2lQ
-            eXFwVVBuaXFpRmVTWjFiQkxJTGNpbXMKLS0tIEtVUnpmTDJGS0dpTVIxYmhCaEV3
-            VXg2aCthYjhxSmFUTkNJbEVqcTJuaWsK+6U7loNZu6yUOOAW7zbELxugLCsgIU+u
-            3qHpVBOgN0jNpMVu14ha0+u4sX/7Po9sLXsDO2zvzgWdmerkZqWq5A==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSYm9wejdYeTl1UGtJL3hQ
+            dXN4VktXNkJzL212clJmUGJBSkd2VjhyNmpVCm9GK3pQQWIzcW9QUlBPOHJKdS9Z
+            YThvWFBLMENhZndyYTZZTFNWaFNyeDQKLS0tIFp4T2R0THQ1bXByQU9EWWJhNnlr
+            VGFHQmJFLzlCZ1cxYjZhTUN4RHIwNEUKAac+nEXcpGdGSEr46FpbDx0KQkQiT38L
+            Ld1yQTMbeK9R60Ntd3PD2xXzV+YTzlWn2fUQcLEblTTb1iyhaQhdww==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age17fq29yexw9rf30je5xp86hdda6tgug52sax7vy0af2sngempqv0qwhe4vr
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHSU1lNWh5eGgveUJtVmls
-            ZkV4V1B0eC9MaGRLeER6MmZuOHplNjNtWnlRCjVWOTNTdmxNRkYvV3ZBNXZsL1hU
-            T0dXMnlrVmhObFIrYnpOR3Q2aENWVU0KLS0tIDhJczNDajJuREFHK3pDVnNBc3dU
-            R1BUTk5nQmtlLzVyNEthejNHY1Zmcm8KwT8XN4rcAkagwdJRAyyV5lYwzrUWAucZ
-            H5zn7Qse+ecjyTt9W3NDKISp6/Fp92ArAoiQYwxevxBB3y9mKTGhsA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrZ01KbXR4bTZ6SFVWTmsz
+            TU5ET3RLVkFVdW1lZkNMUkU2VkZhSWY2aFFFCm5KN2JMdzZhVnk5U0ozRnk2MGhV
+            cU5oanJCY3VnbTVJZkxaVDd1am5zb2cKLS0tIEVFV0Zqd2NtRWJYZXdZMTI2T1pn
+            bVhJV0ozZ3N5U0FmT0JyRXFaYzJnYUEKhkr9SzWVxhGFb5OSJm2GU1ugMxhoQVn7
+            WIaNxycleYpWWHNFOx2HXVdIVjU5c+G2Pd7tFN5p7qC9JhMoTNnSqA==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1wcuzeqxgdmv6ev0ufawnu699pyxrqq565tae79sa2jfgnffvlvmq5xd03h
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBY3RyajZsQlpBK2pubFBy
-            dTRmdG9BV3FBelZ0RWxUdGhVSkZxNjNtNzNjClVKL3BPRUZIcmU5RXNvY0Z0bWVF
-            Um5vNFcxblVvR1U4dHZkamdYVGNxZ2sKLS0tIDBFSjh0RVhTYWl5ZC8ra3c1M3Nq
-            eittTlkvOHNUOGhOd29vek9aOFFsdUkKEeuLNo84lQojwDPEwViEWOqBvfJfay4n
-            yITpK5C7YXvNkVyz5G4AQHqIZCeHal2XCj6O1zPCFZ1h55kdThGhpA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmTjI5OG42dGZsRFJsUURj
+            Y1VsU3hJQUIzWUc4T1NEUE9xYUlHYjF4NFFnCmNlNDNLYU1sb253KzVOZkVFRjc1
+            Y0o3MjhhNzUyRWVJZ25NVllYS2xJUkUKLS0tIEJTWGRJSXJBTGx0dTJaQVBDeWpZ
+            d1RlSWY2empoK1EzTEFTV3ZXQzJJb00Kfk3aPfSYdNX8byV1VnnerM6a4/KlMJ0s
+            5vuOCrDYkoJ5kMOWZs5N9jXa8kCweQ+rMuu7P4OXlVZij61n9WBoyA==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1wj8d6dpv8xt5m2kpusxzfkfuedp5j4qjszrtg0tnzevgkd3sla8q0wms67
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxZnlxUDl0d3pGMUF0L3BY
-            OGNvcm5EbmR0VVBjU1R5QjBwbjZvMkpZMGxVCjlJdC9weklSSndodTJKZTdIbDRN
-            Tk1Nc3VvV3NrSFl5akVPY2hNazV3bFkKLS0tIFR4QmgyNjBISG55bXJDQlNON2h4
-            aXpYL3VKNFprRi9xd09CQkFjS2FVL2cKP6QpBWu2xdSstqb4vmcJ+uN98+IgB7zk
-            j4pYX+Bv8qp3XFHnvJK+f7oZm1V/EJ7HzTYInydEcq3IvXAyUT+1Ew==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGN0xCN2IrYUxEempZR1Js
+            WkRqR1BlLytydGZ4M3hMbUoyeDFCZ3BvZEFrClNWeVF3OGM0dk96MHh0M1VlK2FG
+            K2liWkxDZ1BaeE5ueXNsbjRGZFdrRUkKLS0tIDdmZmlGWEh3VnlJMkQrOXV3YkVt
+            UlpsdDJOd3YxcG1yNmpxZ1ZHTXE5ekUKC0VncUyAiGAcQYEhW07aGgaMnUHtd5/h
+            TsMewblSNM/R5A8X1/mkVmISB1Q2ZTJ9r6ijZh+J8xytUD/6mEmC6Q==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2025-06-20T08:38:06Z"
     mac: ENC[AES256_GCM,data:GcS/KUGp5axi0ampLe2teeckOdwS/B5I5nnKua/fhhCbMGclBitb+DF/FKwui7lrq1hXd4yznCGy0hZMUrjGHDe9bDj2SnFwmNAFKzVITTyK0vpbyXUUCqEQdm91yaf+LDjYI4EqgXobpb0Pz5eXmAOgTJwPDu4doxOKDs0P4CI=,iv:6huAGYlqD0K8CR4RVoxQtPZsoNLqUPDrH/4zYW5ufMs=,tag:HXDMMxl1wiZXuVMkgeHlHA==,type:str]

--- a/secrets/secrets.yaml
+++ b/secrets/secrets.yaml
@@ -11,65 +11,65 @@ sops:
         - recipient: age1q3575mlegx4mzxtmzey5rzg9nwrnwlc9mlr5jeqcfltnzt6gwcqq6jdrka
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXNGgraWpIWmFaeG9veHRS
-            UTByZG9YZ20zVnJ6N3ZYMTJCRGRTeVQydlJVClh5UlczanVrdTR5TlhHVmhLS29U
-            c0RpUDQ5STh5VUpUS1lVUVhaWGRGUWMKLS0tIHVyK3FkbXcyS0xHeVJ4dWtCc0hK
-            Z2Z4cWlOYkY3OFEyRnlab09uaUNFalUK/jATAnlXQQdRGPlk8smO9/gSodhL0p6Y
-            ZixlcVV9rZs+HIeJ5b3dReO8lcASm6m86SxEoNwtnzZtXIe4JgUQhg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDcXVHMW9sdkxrTVJJN09t
+            ODljdk9hbzV4OXYwTWg3SklweTFCckZGY3hrClVVNjYxd1RtV1YxZnV3dWI0M1ds
+            Tld2bnNYZktKTmxVVHpVMlZtdXg1amcKLS0tIHJOQmhmNGhtemlaaWtCSGwrQVFl
+            d2VjNGFMbkZYOHdBRFBpRllBSjFhNWcKvMr6ETrl78mKQPmDdtb7AndBxFBByTy+
+            Ow1gN91Jg3gXnDR8eKxo9wAyL1A1iTkTYScWjSTqqU3Gi7YJgc7mlg==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1qwuz9ud98q82xpresskwkgd20r35u0valpddq973h2a9dad6cyjqxqmzt2
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwbWhaTWlqNGprZU13ZGFv
-            eWx5cGY1b292OHR3MkQvclg3UnV3OGsvdW1zClIrWU5qcWVrTmlZcTRuaGRVL0h4
-            eTQzdE4zMjJXZHBBRDN4ZzRnV3NKdE0KLS0tIEFvbEJES0swT1hWOElWdDFMSnhD
-            NU42UC9BdFpOQkQ3YVRkNWNsbkxBZVEKmCqaEGyuZdI4hWJ6dFSYE/5W9fZee5al
-            ZWflvoiIkisK9XAQfPcuynbq+6b3M2dSFvFWZt1Clj3uvJM/KstOlw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyN2NQN0RaZ2hMSG45aVJu
+            dms1Yit0R3VjSWpMT2FYR2kxN0V1WkIvVEgwCkhKS2tpdnlXK0FIRUp3VXR6bkg3
+            K2NOdDdXWVNhcUJGL3UyZ3Zya0VZTTgKLS0tIHIxa2hYRUd3Q3BqU1RSTjZENEVJ
+            SXNJZXNJaThTMDI3eGFUSUlteW42VHMKphpGQjk9XleV6Vx2/jENYKIactWsSThW
+            8Knz9jLsJ6zRvadLhQOoHb94/S1dTS80a4fUiUA84VBTk5oxaYU1hA==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1hj5dyl0wzlq92ms2hrut6he05dqv0pknlv7wpyv2jywhz2hqwe9qgpt5dl
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMVndNTDBUZ2l2UjlyMDhT
-            NXM5UklMOWdBWEtkblJwQVV1MUFGRGFPRXdVCm9yNHRFRDF5YmE4czNuOStqanox
-            eW1UNEZlb3hjQUFRUUZKVFUzYVpVOEUKLS0tIEd1dlh6MTB5dEowYXcwVGRvQ2ZW
-            N3RLd3RQMkxiZ3VrYmkwYkRuL3AxbVkK3DXIrwtuWvJE4DYgJmn9k+rG/jnK4z5D
-            qjE5fjtz8XbKvXE2hfK+03YUkulPQ/qNikW0KKuH3uPs7g8P1td9KA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBuZHJsQ1BPdHpabFBDTDlG
+            MkxOWjR0Tk1Fa0pDUTlBR1orcVNUWFkreFJBCk9uOFl1MlRxd0ZqbDd3UTgxVjd0
+            enZCd2dIdktvMWhheHBZY1VrbmhCbXcKLS0tIGwrZWtac3RvVkhLUXE5emRQR0RL
+            SmoyQ0JSZGNRWkFRODNXbEo0L2EwUlUKaeldgJR+Kp9ahBkxsxjpDT1K8F5vZcrX
+            bOepfla2ViDUki0B72LC31ch5+wDSPL1W+3OWJ18Bq9Hj9d74J+snA==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age17fq29yexw9rf30je5xp86hdda6tgug52sax7vy0af2sngempqv0qwhe4vr
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1UTBnVTBFUDVWaWlkK2lT
-            QVhOQ3FHaWcraWxINno5RHROMFpOZEhPeGdFCndCMVE4TmtTZHN1ZUZmc0FvV1dp
-            RW5oTlphRnFzS3FrYnl4bHVmbG9Ma00KLS0tIFFWc0tacUV2Z2V0NCsrN3p3aVlC
-            d2pPcU9nemJSWDFyOEp3VDFNTTJHcHMK/wBaJ96I1a2kcBfsYe9pembld5aEfO62
-            pOONxraV25Img0oHj5pdYdZhySP68tBZJlfrwPrrkYZkxJqIyhRXjQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqOWFGTFdldHVqRTJOUFA3
+            QmJnOWNKTFRPQ0xBRWM2ZjhUT0hLaWEyRWkwCktESTVSRkVxQmp6dDloSTNkVHZY
+            d0p6UW5iUTROc2wwcTJhNW5DckZjd0kKLS0tIGdPL0RpdVFNQms3ZU1zdHZyeEth
+            NzNQNzBiSktJQWdyd0VvVjhiMVozbVkKy2ZVBTIrTvWiyjXrOrduHRDQnTesnk19
+            Pdc83m8/paMWDvc/BZlXqUJinsYEPZWE8an4bGFVPVi/BfDDIu4jBw==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1tpupgevxd2d50zv95c098c3xkfqed4zk46h8fag9stadj75dvu0q3wx0mk
+        - recipient: age1wcuzeqxgdmv6ev0ufawnu699pyxrqq565tae79sa2jfgnffvlvmq5xd03h
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEK1VhVUJZOTlNS3d0VUJO
-            NTNPY0FMOG9KZUg2Z0tUb0MwQVU0QWlRblRnClN1SkhXRDhFcFNaRHBteXNNSGdV
-            TmMzc1d3RjlIK0swRStDNXNrdjRYa0EKLS0tIGVPMEQ5QlRXeFF1RE5ZQ2tNaXl5
-            Vytuc2FPYXlXUjFCY1lnaGh1NjMrcHMKjoxB1mMr4efw6lCTnmb5rwylb4wEhGZ6
-            7JtrEzIiiulGs68LFR+FIf+WiU7fGFdt/AD5B+ZZ8eW5rluRObiI2A==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVZUFaQjNsNTgyalExR0M4
+            ZjBHL01taTNmUzlUVXA2UUlPZHBZdm5aUENrCmlLNFhjaXp3a25zZGZaOStTeFJJ
+            M3MzdFlINm90a2MzTzZFN0VFbWFmelEKLS0tIFZIcU1qVDR0UlYxaVlya0pxSytz
+            bjlRQURtNWdvN0Y4eFRBR2lqQkNMTG8KCWvf2HhmwjkOaQrt8/aU0k+EKoC4/7UV
+            ZzqxkIHa5n9gMb6ykRPXTMNootT4SwsyLKfLbnw3YgoOzZHmzZZX2A==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1y2g734aqge4lsvmf8dw6s5rc8rkd0scmfwvxm3nlat6tu7y60a2s94yn0l
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBudXFRMWUzS3FqWkdKUHpp
-            bzZyQVk1RmlsbW1oNWZvajNWMmpHUnpzNVFvClVFRHB0Sm9ySEE3VzR5YjhQKzNR
-            N3VTMXBQbDBjb3NrTGNjM2JHbXRTdDAKLS0tIE5pWTVLQXFjMUJ6dWNhNWxuTGRq
-            ejBmRWFpeHZlY1dXRWMzVEg3b0RTdE0KAh5sUxVifsCTb4kfb93QgOdJF71FH/kt
-            4cCfrkt5h9E0A/YOuk/BsyKWnYieL2zPQLSzg/Jk/d2erdU0VEb1eQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1T0REemlCU092SEc1Tlcz
+            T3R4bU1QNWJabjdSdzAweHZwanB2ZFNIVG5vCmUwcnBKRG01Q3RxUDNTSGVISk9N
+            b2plejhERXVhc1NlQVM4d1o1UkpMQncKLS0tIC92RzZmNEpWbEd2WS82b0pGamFm
+            ZGxreTg1bzRKRGNLUWJnTmNFaWJjbjAKC99mFGELcia6/Q7Z7UkaVIxqpPLs7teS
+            bhojKfOQC2D691pWqsawI9GEULAe5oMXWSV1Xkrzhi+7HlQSHFobIw==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1wj8d6dpv8xt5m2kpusxzfkfuedp5j4qjszrtg0tnzevgkd3sla8q0wms67
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwUHdYelVUalhpRVh1WHVv
-            VkpXaGZiSVV2RlBaTU83Q1NybEJjb3BjVXlnCm1nMWxyajhxb21DOFVKZjNtQ2pq
-            dEp1Q2FOZTNkVnYwbnQwMTZPMzR1ZGcKLS0tIGh3UWg5bjhuTU9CSDBXaXNoYzRw
-            ZXUwM2xYb2tQbmsrZGJsMkZWUVFPU2MKzPYsGrBaGVuRWtJAWI8HT2FBdFKBwpq+
-            CMDCZDt4b6RzHhDlXiIP3BHrcuc23PE/Tm3BKqTC2OiPEgbN3JuKSw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvS29vNzRxY2NwelFCMWdv
+            S3QwdUQ2MERGT2Q0dGk5M2JjdVBkRldLZVNrCjVhNzkxMzVxb1ZTdUllMkRjd2J3
+            WHZwSmVSWDVJSW00Y05uK1E1ejREdjgKLS0tIDhnVFM4M3RwaEZUei9YNU41NWY3
+            Wjc5UnhxbU9lM09ya0FzU2xHRzVVdncKNDMBxtTgcwR65bkNbG+owCPb0WYUnIUp
+            CK3n1kOGL+7yH1YnnaFkme2dGVfDJh/9rHMr0em5p8l4TTlQX/Xdiw==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2025-05-09T08:36:38Z"
     mac: ENC[AES256_GCM,data:shaeh0wx6Z5HsmTuwmP8S78P7n1dH+62P9bGoUJFmkOZFI5JVyq1NLs1tEY819VvYrJnsppvXvyBkX9Z2SDD1CFr/xMx7SxLCY4vqZ+7NRm95pNUex/OsK9o1ilMdYYwvXvcBc/gyc1XZtxliS47quxV1WN25M/a01hrBR+QLnw=,iv:igvmA6KJJRpZuaraLFWArr0kDeu0Ix4QnbWYNl11cKY=,tag:adY8I1qvFvjv9031CzP/Wg==,type:str]


### PR DESCRIPTION
## Summary

  - refresh .sops.yaml + every host secret so the new age keys (keepalived masters, worker nodes, shared cloud-init, GHA key) are present
  - rework the Zagato k3s cluster:
    * flip base-kube to nftables, open VRRP, and add keepalived module with per-master priorities + curl-based health checks
    * retag all node NICs onto VLAN 20, standardize the API server address (10.0.20.11) for masters/workers, and ensure worker SOPS keys are pulled via cloud-init + userborn
  - introduce k3s worker‑N (netboot) profile: containerd disk formatting/mounting, cloud-init token fetch, autologin disabled, immutable `root`/`kubeadmin` users (with erikp hashes + SSH keys) and `nixos` locked out
  - add the Aspen host (default/services/proxmox modules) with its own deploy/flake wiring and firewall/DNS defaults; extend flake packages/deploy targets accordingly
  - misc cleanups: bugatti gains claude-code from pkgs-unstable, connorgolden’s SSH key now bundled in zagato default, flake.lock refreshed