### PR TITLE
Add resilient 1337x provider bridge

### DIFF
--- a/modules/hosts/pilatus/pc24.nix
+++ b/modules/hosts/pilatus/pc24.nix
@@ -85,6 +85,20 @@ in {
         group = "root";
         mode = "0400";
       };
+      browserless-api-key = {
+        sopsFile = ../../../secrets/hosts/pilatus/pc24.yaml;
+        owner = "root";
+        group = "root";
+        mode = "0400";
+        restartUnits = [ "1337x-flaresolverr-bridge.service" ];
+      };
+      kernel-api-key = {
+        sopsFile = ../../../secrets/hosts/pilatus/pc24.yaml;
+        owner = "root";
+        group = "root";
+        mode = "0400";
+        restartUnits = [ "1337x-flaresolverr-bridge.service" ];
+      };
     };
   };
 
@@ -292,6 +306,340 @@ in {
   systemd.services.radarr.serviceConfig.UMask = lib.mkForce "0002";
   systemd.services.lidarr.serviceConfig.UMask = lib.mkForce "0002";
   systemd.services.prowlarr.serviceConfig.UMask = lib.mkForce "0002";
+  systemd.services.prowlarr.environment.DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_HTTP2SUPPORT = "0";
+
+  # 1337x sometimes returns a slow Varnish 503 to Prowlarr's initial request.
+  # Browserless Unblock has a residential-proxy option that succeeds where the
+  # server's shared IP fails Cloudflare. FlareSolverr remains a no-cost fallback.
+  systemd.services."1337x-flaresolverr-bridge" =
+    let
+      bridge = pkgs.writeText "1337x-flaresolverr-bridge.py" ''
+        import json
+        import os
+        import sqlite3
+        import threading
+        import time
+        import urllib.error
+        import urllib.parse
+        import urllib.request
+        from http.server import BaseHTTPRequestHandler, HTTPServer, ThreadingHTTPServer
+
+        BROWSERLESS_ENDPOINT = "https://production-sfo.browserless.io/unblock"
+        FLARESOLVERR_URL = "http://127.0.0.1:8191/v1"
+        KERNEL_ENDPOINT = "https://api.onkernel.com"
+        ORIGIN = "https://1337x.st"
+        REQUEST_LOCK = threading.Lock()
+        METRICS_LOCK = threading.Lock()
+        STATE_DIRECTORY = os.environ.get("STATE_DIRECTORY", "/var/lib/1337x-bridge")
+        DATABASE_PATH = os.path.join(STATE_DIRECTORY, "usage.sqlite3")
+        METRICS = {
+            "started_at": time.time(),
+            "in_flight": 0,
+            "last_usage_refresh": 0.0,
+        }
+
+        os.makedirs(STATE_DIRECTORY, exist_ok=True)
+
+        def database():
+            connection = sqlite3.connect(DATABASE_PATH, timeout=5)
+            connection.execute("PRAGMA journal_mode=WAL")
+            return connection
+
+        with database() as connection:
+            connection.execute("""
+                CREATE TABLE IF NOT EXISTS provider_events (
+                    id INTEGER PRIMARY KEY,
+                    timestamp REAL NOT NULL,
+                    provider TEXT NOT NULL,
+                    success INTEGER NOT NULL,
+                    elapsed_seconds REAL NOT NULL
+                )
+            """)
+            connection.execute("""
+                CREATE TABLE IF NOT EXISTS provider_usage (
+                    provider TEXT PRIMARY KEY,
+                    fetched_at REAL NOT NULL,
+                    payload TEXT NOT NULL
+                )
+            """)
+
+        def store_usage(provider, payload):
+            with database() as connection:
+                connection.execute(
+                    "INSERT OR REPLACE INTO provider_usage(provider, fetched_at, payload) VALUES (?, ?, ?)",
+                    (provider, time.time(), json.dumps(payload)),
+                )
+
+        def refresh_provider_usage():
+            with METRICS_LOCK:
+                if time.time() - METRICS["last_usage_refresh"] < 60:
+                    return
+                METRICS["last_usage_refresh"] = time.time()
+            try:
+                token = credential("browserless-api-key")
+                url = "https://api.browserless.io/v1/account/usage?token=" + urllib.parse.quote(token, safe="")
+                with urllib.request.urlopen(url, timeout=15) as response:
+                    store_usage("browserless_account", json.load(response))
+            except (OSError, RuntimeError, ValueError, urllib.error.URLError) as error:
+                store_usage("browserless_account_error", {"error": type(error).__name__})
+            try:
+                token = credential("kernel-api-key")
+                request = urllib.request.Request(
+                    "https://api.onkernel.com/browsers?include_deleted=true&limit=100",
+                    headers={"Authorization": "Bearer " + token},
+                )
+                with urllib.request.urlopen(request, timeout=15) as response:
+                    sessions = json.load(response)
+                store_usage("kernel_sessions", {
+                    "session_count": len(sessions),
+                    "uptime_ms": sum(session.get("usage", {}).get("uptime_ms", 0) for session in sessions),
+                    "source": "Kernel browser sessions API (not an account credit balance)",
+                })
+            except (OSError, RuntimeError, ValueError, urllib.error.URLError) as error:
+                store_usage("kernel_sessions_error", {"error": type(error).__name__})
+
+        def call_provider(name, action):
+            started = time.monotonic()
+            try:
+                value = action()
+            except Exception:
+                with database() as connection:
+                    connection.execute(
+                        "INSERT INTO provider_events(timestamp, provider, success, elapsed_seconds) VALUES (?, ?, ?, ?)",
+                        (time.time(), name, 0, time.monotonic() - started),
+                    )
+                raise
+            with database() as connection:
+                connection.execute(
+                    "INSERT INTO provider_events(timestamp, provider, success, elapsed_seconds) VALUES (?, ?, ?, ?)",
+                    (time.time(), name, 1, time.monotonic() - started),
+                )
+            return value
+
+        def metrics_snapshot():
+            refresh_provider_usage()
+            with database() as connection:
+                rows = connection.execute("""
+                    SELECT provider, COUNT(*), COALESCE(SUM(success), 0),
+                           COUNT(*) - COALESCE(SUM(success), 0), COALESCE(SUM(elapsed_seconds), 0)
+                    FROM provider_events GROUP BY provider
+                """).fetchall()
+                usage_rows = connection.execute(
+                    "SELECT provider, fetched_at, payload FROM provider_usage"
+                ).fetchall()
+            providers = {
+                name: {
+                    "attempts": attempts,
+                    "successes": successes,
+                    "failures": failures,
+                    "elapsed_seconds": round(elapsed, 2),
+                }
+                for name, attempts, successes, failures, elapsed in rows
+            }
+            for name in ("browserless", "kernel", "flaresolverr"):
+                providers.setdefault(name, {"attempts": 0, "successes": 0, "failures": 0, "elapsed_seconds": 0.0})
+            with METRICS_LOCK:
+                return {
+                    "uptime_seconds": round(time.time() - METRICS["started_at"], 1),
+                    "in_flight": METRICS["in_flight"],
+                    "persistent_database": DATABASE_PATH,
+                    "providers": providers,
+                    "provider_api_usage": {
+                        provider: {"fetched_at": fetched_at, "data": json.loads(payload)}
+                        for provider, fetched_at, payload in usage_rows
+                    },
+                }
+
+        def credential(name):
+            credential_dir = os.environ.get("CREDENTIALS_DIRECTORY")
+            if not credential_dir:
+                raise RuntimeError(f"{name} credential is unavailable")
+            with open(os.path.join(credential_dir, name), encoding="utf-8") as file:
+                value = file.read().strip()
+            if not value:
+                raise RuntimeError(f"{name} credential is empty")
+            return value
+
+        def browserless_fetch(path):
+            token = credential("browserless-api-key")
+            payload = json.dumps({
+                "url": ORIGIN + path,
+                "content": True,
+                "cookies": False,
+                "screenshot": False,
+                "browserWSEndpoint": False,
+            }).encode()
+            endpoint = BROWSERLESS_ENDPOINT + "?token=" + urllib.parse.quote(token, safe="") + "&proxy=residential"
+            request = urllib.request.Request(
+                endpoint,
+                data=payload,
+                headers={"Content-Type": "application/json"},
+            )
+            with urllib.request.urlopen(request, timeout=110) as response:
+                result = json.load(response)
+            body = result.get("content")
+            if not body or "/torrent/" not in body:
+                raise RuntimeError("Browserless returned no 1337x results")
+            return body
+
+        def kernel_fetch(path):
+            token = credential("kernel-api-key")
+            headers = {
+                "Authorization": "Bearer " + token,
+                "Content-Type": "application/json",
+            }
+
+            def request(url, data=None, timeout=75, method=None):
+                payload = None if data is None else json.dumps(data).encode()
+                with urllib.request.urlopen(
+                    urllib.request.Request(url, data=payload, headers=headers, method=method),
+                    timeout=timeout,
+                ) as response:
+                    raw = response.read()
+                    return json.loads(raw) if raw else None
+
+            target_url = ORIGIN + path
+            browser = request(KERNEL_ENDPOINT + "/browsers", {
+                "stealth": True,
+                "headless": False,
+                "start_url": target_url,
+                "timeout_seconds": 120,
+            }, timeout=30)
+            session_id = browser.get("session_id")
+            if not session_id:
+                raise RuntimeError("Kernel returned no browser session")
+            try:
+                code = """
+                  try {
+                    await page.waitForFunction(
+                      () => document.querySelectorAll('a[href*=\"/torrent/\"]').length > 0,
+                      {timeout: 55000},
+                    );
+                  } catch (_) {}
+                  return await page.content();
+                """
+                result = request(
+                    KERNEL_ENDPOINT + "/browsers/" + urllib.parse.quote(session_id, safe="") + "/playwright/execute",
+                    {"code": code, "timeout_sec": 120},
+                    timeout=125,
+                )
+                body = result.get("result")
+                if not isinstance(body, str) or "/torrent/" not in body:
+                    raise RuntimeError("Kernel returned no 1337x results")
+                return body
+            finally:
+                # Browser time is billable; delete every short-lived fallback session.
+                try:
+                    request(
+                        KERNEL_ENDPOINT + "/browsers/" + urllib.parse.quote(session_id, safe=""),
+                        method="DELETE",
+                        timeout=20,
+                    )
+                except (OSError, urllib.error.URLError):
+                    pass
+
+        def flaresolverr_fetch(path):
+            payload = json.dumps({
+                "cmd": "request.get",
+                "url": ORIGIN + path,
+                "maxTimeout": 60000,
+            }).encode()
+            request = urllib.request.Request(
+                FLARESOLVERR_URL,
+                data=payload,
+                headers={"Content-Type": "application/json"},
+            )
+            with urllib.request.urlopen(request, timeout=75) as response:
+                result = json.load(response)
+            solution = result.get("solution", {})
+            body = solution.get("response")
+            if result.get("status") != "ok" or body is None:
+                raise RuntimeError("FlareSolverr returned no solution")
+            return body, solution.get("status", 502)
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                with METRICS_LOCK:
+                    METRICS["in_flight"] += 1
+                try:
+                    # Avoid concurrent browser challenges and paid-proxy requests.
+                    with REQUEST_LOCK:
+                        try:
+                            body = call_provider("browserless", lambda: browserless_fetch(self.path))
+                            status = 200
+                        except (OSError, RuntimeError, ValueError, urllib.error.URLError):
+                            try:
+                                body = call_provider("kernel", lambda: kernel_fetch(self.path))
+                                status = 200
+                            except (OSError, RuntimeError, ValueError, urllib.error.URLError):
+                                body, status = call_provider("flaresolverr", lambda: flaresolverr_fetch(self.path))
+                    self.send_response(status)
+                    self.send_header("Content-Type", "text/html; charset=utf-8")
+                    self.send_header("Content-Length", str(len(body.encode())))
+                    self.end_headers()
+                    self.wfile.write(body.encode())
+                except (OSError, RuntimeError, ValueError, urllib.error.URLError) as error:
+                    body = b"1337x bridge upstream unavailable"
+                    self.send_response(502)
+                    self.send_header("Content-Type", "text/plain; charset=utf-8")
+                    self.send_header("Content-Length", str(len(body)))
+                    self.end_headers()
+                    self.wfile.write(body)
+                finally:
+                    with METRICS_LOCK:
+                        METRICS["in_flight"] -= 1
+
+            def log_message(self, format, *args):
+                pass
+
+        class StatsHandler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                snapshot = metrics_snapshot()
+                if self.path == "/metrics":
+                    body = json.dumps(snapshot, indent=2).encode()
+                    content_type = "application/json; charset=utf-8"
+                elif self.path == "/" or self.path == "/index.html":
+                    payload = json.dumps(snapshot, indent=2)
+                    body = ("<!doctype html><title>1337x bridge costs</title>"
+                        "<style>body{background:#101218;color:#e8eaf0;font:16px system-ui;margin:3rem}pre{background:#181b24;padding:1.5rem;border-radius:8px}</style>"
+                        "<h1>1337x bridge usage</h1><p>Refreshes every 10 seconds. <a href='/metrics'>JSON</a></p>"
+                        "<pre id='metrics'></pre><script>const e=document.getElementById('metrics');async function f(){e.textContent=JSON.stringify(await fetch('/metrics').then(r=>r.json()),null,2)}f();setInterval(f,10000)</script>").encode()
+                    content_type = "text/html; charset=utf-8"
+                else:
+                    self.send_error(404)
+                    return
+                self.send_response(200)
+                self.send_header("Content-Type", content_type)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, format, *args):
+                pass
+
+        threading.Thread(
+            target=ThreadingHTTPServer(("0.0.0.0", 1337), StatsHandler).serve_forever,
+            daemon=True,
+        ).start()
+        HTTPServer(("127.0.0.1", 8192), Handler).serve_forever()
+      '';
+    in {
+      description = "1337x Browserless, Kernel, and FlareSolverr bridge for Prowlarr";
+      after = [ "flaresolverr.service" ];
+      requires = [ "flaresolverr.service" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = "${pkgs.python3}/bin/python3 ${bridge}";
+        Restart = "always";
+        RestartSec = 2;
+        DynamicUser = true;
+        StateDirectory = "1337x-bridge";
+        LoadCredential = [
+          "browserless-api-key:${config.sops.secrets.browserless-api-key.path}"
+          "kernel-api-key:${config.sops.secrets.kernel-api-key.path}"
+        ];
+      };
+    };
 
   networking = {
     hostName = "pilatus-nix";
@@ -299,7 +647,7 @@ in {
     nameservers = [ "1.1.1.1" "8.8.4.4" "8.8.8.8" "9.9.9.9" ];
     firewall = {
       enable = true;
-      allowedTCPPorts = [ 22 80 443 8007 ];
+      allowedTCPPorts = [ 22 80 443 1337 8007 ];
     };
   };
 

--- a/secrets/hosts/pilatus/pc24.yaml
+++ b/secrets/hosts/pilatus/pc24.yaml
@@ -1,10 +1,11 @@
 airvpn-san-jose-imai-conf: ENC[AES256_GCM,data:ycYPb3R7nSdNztCpkI71r48/n5LARHbhPIgG5T+/jjORKhGhzugdVy2UKLpoxYgUbfBZ8oM5cXFqP2YDnBsK+leWrwpebGqTatH0OcDhTXUnWc8nGv3jtOI5b+afQBGwPIkHElliVSRex3jEraeWFRvk3/IJPzK4pxEeAaZqRC5yeGb/i3H8+4BXmI4Hk5+EngaMWXMR+exqeChC4BqzTwrwxpIGACMS/QH32/vJPPIvAwrcegJBFfkqO4Px+gt0NH2A5vAe9A/Y7vVzcEMDE8zo7zc8mfnu6EPMYtbt1YCS6del4QE+x6qGZldaJ0KTezI27ym57YVElUUVkcg6uus/+r0OfqGepxCwFwOfXAcs2OZBeKz2N6aJD0IvxOrYJxCA/jzBcFIBjr8gTqh+Qm7wCKOwZupN0z4H7C5R45Cmh1+UEsGqX3w9yeu9Eo5r7gbmhqueqfhmfm4v+Fy+vTZXqW88wNPas7eQy+wrhcRb5pcR6cWaae3bJ++UWvM/DnzoGIzj9k60b8BaVn5Jrg==,iv:TFhbl31h/1pv1cIA15OKFp8kueHsUJbVBirQIxN7wYc=,tag:RwvnB/rw3JA/37dw4xLBCA==,type:str]
 palworld-admin-password: ENC[AES256_GCM,data:E1OeJGb1aO7IvBgl70rzIIOHxs5ncMjMX5iaSnkI,iv:5O3DiFuBz3MjRnhwBHHi9awII7eIHjdoDXsGVptDI7U=,tag:rFhQtl9ZAGdfqW2OOm6Ufg==,type:str]
 palworld-server-password: ENC[AES256_GCM,data:EWYs6/Y9bqa6aPbhKv8Jht7qBUFo7uk6lMlMV+8=,iv:rz2IZ+82H3mJVoJv3LkoYbWfJuvJ3T0v6zS46WzBVH4=,tag:vzuWp5esUOlsRLErD0jnzQ==,type:str]
+browserless-api-key: ENC[AES256_GCM,data:lA7Mq/ixlrhTvvnxXMKn2SsRt6rbiszwX2YUKL4JlT51aN62AgIAW04uRMW3k4DcNw==,iv:lUH6Wk/jFOVIqcz6mphrXjVrarnzZ08COILjW/beGiU=,tag:NS2Ensub4puSOatpuc1vWg==,type:str]
+kernel-api-key: ENC[AES256_GCM,data:mZrQmz8xgHzptWJwgX/kBdwp7FcjPrjrp+DyebsJhdENrbkK2NBrQizZe7dF+ZVaVq5NbUZ2v2kFacxKUysZn5N6YOmokD6k9gGJKdlUyLS0WkU=,iv:U+kD7d0NavP+yXwPxsI4Gk6GeLZx/g/3IrW7mYxl6Eg=,tag:KV6VJaVczKQho7lHObYJUg==,type:str]
 sops:
     age:
-        - recipient: age17fq29yexw9rf30je5xp86hdda6tgug52sax7vy0af2sngempqv0qwhe4vr
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxcmtneTE4akpyOW9TY29F
             NFJQU0NuaTRGV3VQSENadmltOERRckZVWENRCjBSekJzTkd4Q1dWR2NIcjNLUEsz
@@ -12,8 +13,8 @@ sops:
             REo0TEhwRGJRZzY5dGVwWHp1VXdlV0UKwfq507zKvHMRBM4SJZj3EGRQwqFKRC4u
             feYQCmQZ9nbnVU6Bpm5yDdk3leSc80ezPDHUy7A5TpCBxe7axitovg==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1wcuzeqxgdmv6ev0ufawnu699pyxrqq565tae79sa2jfgnffvlvmq5xd03h
-          enc: |
+          recipient: age17fq29yexw9rf30je5xp86hdda6tgug52sax7vy0af2sngempqv0qwhe4vr
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnQjMzVmczbjBqejIzdVIy
             cko4RnZkcHUvd05aRjU3dWpmRG9vZkQxelQwClZET0NML0VPWThVZUhkREl0SWRj
@@ -21,8 +22,8 @@ sops:
             WldRT3ZkdmtWdE92Q2srVnRBYkVoMmMK9zNg1UHIKfRRzhjKbrzJ/hgc4qQ8EDOP
             K00173PkyZPcpYDMGmvFyH/7tRx2l0j1TOHOiiPqsbYWVEbOWJYmQA==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1y2g734aqge4lsvmf8dw6s5rc8rkd0scmfwvxm3nlat6tu7y60a2s94yn0l
-          enc: |
+          recipient: age1wcuzeqxgdmv6ev0ufawnu699pyxrqq565tae79sa2jfgnffvlvmq5xd03h
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6Q0lHTnlPNkg2SmtMZE02
             d3MrWDZvNjhBbGhRRExlRGpaQjR1bjdLNUhrCndwbExOaGpvWityTk9BWDI0NVQ3
@@ -30,8 +31,8 @@ sops:
             ekIxUG1IdG9sMHcveFdzZ3BWekR4cU0KSbNAXDlvTt7iiN5k+IdjNmrQ2T1hhgM8
             OH/8IsuL3YegDZRsobTVnsdPIlhnFqAycx9DAo6inX9bA2esDes4uA==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1wj8d6dpv8xt5m2kpusxzfkfuedp5j4qjszrtg0tnzevgkd3sla8q0wms67
-          enc: |
+          recipient: age1y2g734aqge4lsvmf8dw6s5rc8rkd0scmfwvxm3nlat6tu7y60a2s94yn0l
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQQnhDbmkwQUlzQW5TSkhx
             NHRFMUFNaXo0akpNaU9DVUY3YXZVREJzcldJClFRd2U3a1AwSUhTVS9LcGZpaDlu
@@ -39,7 +40,8 @@ sops:
             TnJOTGJ1Ym1laXFzMzd3cWpmY3BnaGsKUdAe9anIsy2YmeyYA7RL1obbdSlijN2h
             kiF7PgVBGbXBfQYI0C87E/ar8XckYgGWMlxqh2q3G6nFNAlIitCC9Q==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-02-02T01:03:24Z"
-    mac: ENC[AES256_GCM,data:GIMD1lIgv8dUalQ5tSLLk0Dau8VmVNWbs+Iw5ug/L2XMxVJAzFVIdFk60gKD0taE3tmUrxjR++p5zoCCiKJ9k36jp732FjZ9PuSEgpaOLfhAXuTvMFmvr3oBvydM4uo8Vt5H6HkiVFZDPLi6sdqcV8gsVeUpx234/2YuOiHx3n0=,iv:f5/sEluQBVC6RWHEmQ/IjDuz7CvCgH7YV+eiOpnYXDw=,tag:QsbJHcfK6mp1OhK6vdn/Dw==,type:str]
+          recipient: age1wj8d6dpv8xt5m2kpusxzfkfuedp5j4qjszrtg0tnzevgkd3sla8q0wms67
+    lastmodified: "2026-07-25T06:57:51Z"
+    mac: ENC[AES256_GCM,data:207XCd67NtT3ovlTxJZNdNIO5w47ws9UqXnfHUUhdPARL+FAtkdefUCmLcGKk+wKPmQYBZIpDPkwmgIjLs9UoudaRMAJPv8lbkQeYpvEeSytsZxJNqwKsHrObFr7mfabZpjOb6F0XAztN9LtNMfH/nPleUdGhdc7VIPZP+xC298=,iv:3XQP4iLNzKl7q878/S+q0fxfjVMNIwf6efAifED53Ys=,tag:jpwcYmWr+fVhGZhPouEBRg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0


### PR DESCRIPTION
## What changed

- Route 1337x searches through Browserless, Kernel, and FlareSolverr fallback providers.
- Store provider credentials with SOPS and expose persistent usage telemetry on port 1337.
- Add Browserless account usage and Kernel session-usage reporting.

## Validation

- Remote Nix activation completed successfully.
- Radarr returned 20 1337x releases for Before Midnight.
- Metrics endpoint verified on pc24.